### PR TITLE
Mcore floating output amounts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ unsigned int nCoinCacheSize = 5000;
 /** Fees smaller than this (in satoshi) are considered zero fee (for transaction creation) */
 int64_t CTransaction::nMinTxFee = 10000;  // Override with -mintxfee
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
-int64_t CTransaction::nMinRelayTxFee = 1000;
+int64_t CTransaction::nMinRelayTxFee = 1001; // Override with -minrelaytxfee
 
 static CMedianFilter<int> cPeerBlockCounts(8, 0); // Amount of blocks that other nodes claim to have
 

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -5030,7 +5030,6 @@ int i = 0;
 std::vector<CPubKey> pubkeys;
 pubkeys.resize(n_keys);
 CWallet *wallet = pwalletMain;
-const int64_t nDustLimit = MP_DUST_LIMIT;
 
   txid = 0;
 
@@ -5074,19 +5073,19 @@ const int64_t nDustLimit = MP_DUST_LIMIT;
   CScript scriptPubKey;
 
   // the 1-multisig-2 Class B with data & sender
-  vecSend.push_back(make_pair(multisig_output, nDustLimit));
+  vecSend.push_back(make_pair(multisig_output, GetDustLimit(multisig_output)));
 
   // the reference/recepient/receiver
   if (!receiverAddress.empty())
   {
     // Send To Owners is the first use case where the receiver is empty
     scriptPubKey.SetDestination(CBitcoinAddress(receiverAddress).Get());
-    vecSend.push_back(make_pair(scriptPubKey, nDustLimit));
+    vecSend.push_back(make_pair(scriptPubKey, GetDustLimit(scriptPubKey)));
   }
 
   // the marker output
   scriptPubKey.SetDestination(CBitcoinAddress(exodus).Get());
-  vecSend.push_back(make_pair(scriptPubKey, nDustLimit));
+  vecSend.push_back(make_pair(scriptPubKey, GetDustLimit(scriptPubKey)));
 
   // selected in the parent function, i.e.: ensure we are only using the address passed in as the Sender
   if (!coinControl.HasSelected()) return -6;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -4996,6 +4996,31 @@ CWallet *wallet = pwalletMain;
 }
 
 //
+// Determines minimum output amount to be spent by an output based on
+// scriptPubKey size in relation to the minimum relay fee.
+// 
+// This method is very related with IsDust(nMinRelayTxFee) in core.h.
+//
+int64_t GetDustLimit(const CScript& scriptPubKey)
+{
+    // The total size is based on a typical scriptSig size of 148 byte,
+    // 8 byte accounted for the size of output value and the serialized
+    // size of scriptPubKey.
+    size_t nSize = ::GetSerializeSize(scriptPubKey, SER_DISK, 0) + 156;
+    
+    // The minimum relay fee dictates a threshold value under which a
+    // transaction won't be relayed.
+    int64_t nRelayTxFee = CTransaction::nMinRelayTxFee;
+    
+    // A transaction is considered as "dust", if less than 1/3 of the
+    // minimum fee required to relay a transaction is spent by one of
+    // it's outputs. The minimum relay fee is defined per 1000 byte.
+    int64_t nDustLimit = 1 + (((nSize * nRelayTxFee * 3) - 1) / 1000);
+    
+    return nDustLimit;
+}
+
+//
 // Do we care if this is true: pubkeys[i].IsCompressed() ???
 // returns 0 if everything is OK, the transaction was sent
 static int ClassB_send(const string &senderAddress, const string &receiverAddress, const string &data_packet, CCoinControl &coinControl, uint256 & txid)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -28,7 +28,7 @@ extern int64_t nTransactionFee;
 extern bool bSpendZeroConfChange;
 
 // -paytxfee default
-static const int64_t DEFAULT_TRANSACTION_FEE = 0;
+static const int64_t DEFAULT_TRANSACTION_FEE = 10000;
 // -paytxfee will warn if called with a higher fee than this amount (in satoshis) per KB
 static const int nHighTransactionFeeWarning = 0.01 * COIN;
 


### PR DESCRIPTION
Replaces #66 with an up-to-date version.

---
1. `GetDustLimit(const CScript&)` is used instead of `MP_DUST_LIMIT`. See 426592e for additional details.
2. `nMinRelayTxFee` was set to 1001 which results in output amounts of:
   - 552 (pay-to-pubkey-hash)
   - 685 (multisig, two compressed public keys)
   - 781 (multisig, one uncompressed, one compressed public key)
   - 787 (multisig, three compressed public keys)
   - 883 (multisig, one uncompressed, two compressed public keys)

Set this value to 10000 to mirror the old "6000 / packet rule" with slightly tighter (and more accurate) amounts.

The default value was set to 1000 back in November 2013, so this amount should be safe. +1 Satoshi is used as marker. Increment further, if a new marker is needed.

The `minrelaytxfee` can be set via bitcoin.conf or startup parameter. Note: `minrelaytxfee=0.00001001` in decimal form must used! Verify via `getinfo` and look out for `relayfee`.
1. `DEFAULT_TRANSACTION_FEE` was set to 10000 from 0.

This simply mirrors the actual default value and has no effect, unless the mintxfee is overwritten. In this case all it does is to act as safeguard for the case that only `mintxfee` was set and `paytxfee` was forgotten.

---

Get minimum output amount to be spent by an output based on scriptPubKey size in relation to the minimum relay fee.

The minimum relay fee can be defined as command-line argument `-minrelayfee=<amount>` or `minrelayfee=<amount>` in bitcoin.conf.

As per default `minrelayfee=0.00001` is used which results in the following dust limits:
- Pay-to-pubkey-hash (34 byte): 0.00000546 BTC
- Multisig, two compressed public keys (80 byte): 0.00000684 BTC
- Multisig, one compressed, one uncompressed public key (112 byte): 0.00000780 BTC
- Multisig, three compressed public keys (114 byte): 0.00000786 BTC
- Multisig, one uncompressed, two compressed public keys (146 byte): 0.00000882 BTC

Related:
- core.h: bool IsDust(int64_t nMinRelayTxFee)
- init.cpp: int64_t CTransaction::nMinRelayTxFee
