### PR TITLE
Managed tokens: add missing property reference

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -5996,6 +5996,7 @@ Value gettransaction_MP(const Array& params, bool fHelp)
                                      case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
                                           propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
                                           amount = 0; // crowdsale txs always create zero tokens
+                                     break;
                                      case MSC_TYPE_CREATE_PROPERTY_MANUAL:
                                           propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
                                           amount = 0; // issuance of a managed token does not create tokens
@@ -6240,6 +6241,10 @@ string sAddress = "";
                                           propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
                                           amount = 0; // crowdsale txs always create zero tokens
                                      break;
+                                     case MSC_TYPE_CREATE_PROPERTY_MANUAL:
+                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                          amount = 0; // issuance of a managed token does not create tokens
+                                     break;
                                      case MSC_TYPE_SIMPLE_SEND:
                                           if (0 == mp_obj.step2_Value())
                                           {
@@ -6480,6 +6485,10 @@ bool addressFilter;
                                      case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
                                           propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
                                           amount = 0; // crowdsale txs always create zero tokens
+                                     break;
+                                     case MSC_TYPE_CREATE_PROPERTY_MANUAL:
+                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                          amount = 0; // issuance of a managed token does not create tokens
                                      break;
                                      case MSC_TYPE_SIMPLE_SEND:
                                           if (0 == mp_obj.step2_Value())

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -5996,6 +5996,9 @@ Value gettransaction_MP(const Array& params, bool fHelp)
                                      case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
                                           propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
                                           amount = 0; // crowdsale txs always create zero tokens
+                                     case MSC_TYPE_CREATE_PROPERTY_MANUAL:
+                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                          amount = 0; // issuance of a managed token does not create tokens
                                      break;
                                      case MSC_TYPE_SIMPLE_SEND:
                                           if (0 == mp_obj.step2_Value())


### PR DESCRIPTION
When retrieving information about the issuance of a managed token, the property id and information that comes with property data is currently missing.
