### PR TITLE
Refactor RPC to core function and add issuances, grants, revokes

### DIFF
--- a/doc/apidocumentation.md
+++ b/doc/apidocumentation.md
@@ -154,12 +154,13 @@ $src/mastercored gettransaction_MP d2907fe2c716fc6d510d63b52557907445c784cb2e8ae
 ```
 
 ###Listing Historical Transactions
-The **listtransactions_MP** call allows for retrieval of the last n Master Protocol transactions from the wallet.
+The **listtransactions_MP** call allows for retrieval of the last n Master Protocol transactions from the wallet, if desired filtered on address.
 
 **Required Parameters**
 - There are no required parameters for this call.  Calling with no parameters will default to all addresses in the wallet and the last 10 transactions.
 
 **Additional Optional Parameters**
+- **_address (string):_** A valid bitcoin address to filter on or * for all addresses in the wallet
 - **_count (integer):_** The number of recent transactions to return
 - **_skip (integer):_** The number of recent transactions to skip
 - **_startblock (integer):_** Only show transactions at or after this block height
@@ -171,7 +172,7 @@ Optional parameters can be combined as follows ```listtransactions_MP 50 100``` 
 Optional parameters can be combined as follows ```listtransactions_MP 99999 0 301000 302000``` to list the 99999 most recent transactions across all addresses in the wallet between blocks 3010$
 
 ```
-$src/bitcoind listtransactions_MP 2
+$src/bitcoind listtransactions_MP 1MCHESTbJhJK27Ygqj4qKkx4Z4ZxhnP826 2
 [
     {
         "txid" : "0964e197c9140e4b5a2720d3f6c1345d01ca5813652da88b6b41fe7331691778",
@@ -202,77 +203,6 @@ $src/bitcoind listtransactions_MP 2
 ]
 ```
 *Please note, listtransactions_MP currently supports transactions available in the wallet only.*
-
-###Searching Historical Transactions
-The **searchtransactions_MP** call allows for retrieval of the last n Master Protocol transactions, if desired filtered on address.
-
-**Required Parameters**
-- There are no required parameters for this call.  Calling with no parameters will default to all addresses in the wallet and the last 10 transactions.
-
-**Additional Optional Parameters**
-- **_address (string):_** A valid bitcoin address to filter on or * for all addresses in the wallet
-- **_count (integer):_** The number of recent transactions to return
-- **_skip (integer):_** The number of recent transactions to skip 
-- **_startblock (integer):_** Only show transactions at or after this block height
-- **_endblock (integer):_** Only show transactions at or before this block height
-
-**Examples**
-
-Optional parameters can be combined as follows ```searchtransactions_MP "*" 50 100``` to search the 50 most recent transactions across all addresses in the wallet, skipping the first 100.
-Optional parameters can be combined as follows ```searchtransactions_MP "*" 99999 0 301000 302000``` to search the 99999 most recent transactions across all addresses in the wallet between blocks 301000 and 302000. 
-
-```
-$src/mastercored searchtransactions_MP mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3
-[
-    {
-        "txid" : "fda128e34edc48426ca930df6167e4560cef9cda2192e37be69c965e9c5dd9d1",
-        "sendingaddress" : "mscsir9qKUYry5SqaW19T7fTriDw2BzYvD",
-        "referenceaddress" : "mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3",
-        "direction" : "in",
-        "confirmations" : 1457,
-        "blocktime" : 1403126898,
-        "blockindex" : 7,
-        "type" : "Simple Send",
-        "currency" : 1,
-        "divisible" : true,
-        "amount" : "123456.00000000",
-        "valid" : true
-    },
-    {
-        "txid" : "33e4ea9a43102f9ad43b086d2bcf9478c67b5a1e64ce7dfc64bfe3f94b7f9222",
-        "sendingaddress" : "mscsir9qKUYry5SqaW19T7fTriDw2BzYvD",
-        "referenceaddress" : "mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3",
-        "direction" : "in",
-        "confirmations" : 1454,
-        "blocktime" : 1403129492,
-        "blockindex" : 4,
-        "type" : "Simple Send",
-        "currency" : 1,
-        "divisible" : true,
-        "amount" : "222.00000000",
-        "valid" : true
-    },
-    {
-        "txid" : "c93a8622b6784b4cd5e109bea423553ed729b675965b6820837f80513be04852",
-        "sendingaddress" : "myN6HXmFhmMRo1bzfNXBDxTALYsh3EjXxk",
-        "referenceaddress" : "mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3",
-        "direction" : "out",
-        "confirmations" : 906,
-        "blocktime" : 1403293908,
-        "blockindex" : 2,
-        "type" : "Simple Send",
-        "currency" : 1,
-        "divisible" : true,
-        "amount" : 50.12340000,
-        "valid" : true
-    }
-]
-```
-```
-{"jsonrpc":"1.0","id":"1","method":"searchransactions_MP","params":["mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3"]}
-{"result":[{"txid":"fda128e34edc48426ca930df6167e4560cef9cda2192e37be69c965e9c5dd9d1","sendingaddress":"mscsir9qKUYry5SqaW19T7fTriDw2BzYvD","referenceaddress":"mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3","direction":"in","confirmations":1457,"blocktime":1403126898,"blockindex":7,"type":"Simple Send","currency":1,"divisible":true,"amount":"123456.00000000","valid":true},{"txid":"33e4ea9a43102f9ad43b086d2bcf9478c67b5a1e64ce7dfc64bfe3f94b7f9222","sendingaddress":"mscsir9qKUYry5SqaW19T7fTriDw2BzYvD","referenceaddress":"mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3","direction":"in","confirmations":1454,"blocktime":1403129492,"blockindex":4,"type":"Simple Send","currency":1,"divisible":true,"amount":"222.00000000","valid":true},{"txid":"c93a8622b6784b4cd5e109bea423553ed729b675965b6820837f80513be04852","sendingaddress":"myN6HXmFhmMRo1bzfNXBDxTALYsh3EjXxk","referenceaddress":"mtGfANEnFsniGzWDt87kQg4zJunoQbT6f3","direction":"out","confirmations":906,"blocktime":1403293908,"blockindex":2,"type":"Simple Send","currency":1,"divisible":true,"amount":"50.12340000","valid":true}],"error":null,"id":"1"}
-```
-*Please note, searchttransactions_MP currently supports transactions available in the wallet only.*
 
 ###Retrieving information about a Master Protocol property
 The **getproperty_MP** call allows for retrieval of information about a Master Protocol property.

--- a/doc/apidocumentation.md
+++ b/doc/apidocumentation.md
@@ -166,9 +166,9 @@ The **listtransactions_MP** call allows for retrieval of the last n Master Proto
 - **_startblock (integer):_** Only show transactions at or after this block height
 - **_endblock (integer):_** Only show transactions at or before this block height
 
-Optional parameters can be combined as follows ```listtransactions_MP 50 100``` to list the 50 most recent transactions across all addresses in the wallet, skipping the first 100.
+Optional parameters can be combined as follows ```listtransactions_MP "*" 50 100``` to list the 50 most recent transactions across all addresses in the wallet, skipping the first 100.
 
-Optional parameters can be combined as follows ```listtransactions_MP 99999 0 301000 302000``` to list the 99999 most recent transactions across all addresses in the wallet between blocks 301000 and 302000.
+Optional parameters can be combined as follows ```listtransactions_MP "*" 99999 0 301000 302000``` to list the 99999 most recent transactions across all addresses in the wallet between blocks 301000 and 302000.
 
 **Examples**
 

--- a/doc/apidocumentation.md
+++ b/doc/apidocumentation.md
@@ -166,10 +166,10 @@ The **listtransactions_MP** call allows for retrieval of the last n Master Proto
 - **_startblock (integer):_** Only show transactions at or after this block height
 - **_endblock (integer):_** Only show transactions at or before this block height
 
-**Examples**
-
 Optional parameters can be combined as follows ```listtransactions_MP 50 100``` to list the 50 most recent transactions across all addresses in the wallet, skipping the first 100.
-Optional parameters can be combined as follows ```listtransactions_MP 99999 0 301000 302000``` to list the 99999 most recent transactions across all addresses in the wallet between blocks 3010$
+Optional parameters can be combined as follows ```listtransactions_MP 99999 0 301000 302000``` to list the 99999 most recent transactions across all addresses in the wallet between blocks 301000 and 302000.
+
+**Examples**
 
 ```
 $src/bitcoind listtransactions_MP 1MCHESTbJhJK27Ygqj4qKkx4Z4ZxhnP826 2

--- a/doc/apidocumentation.md
+++ b/doc/apidocumentation.md
@@ -167,6 +167,7 @@ The **listtransactions_MP** call allows for retrieval of the last n Master Proto
 - **_endblock (integer):_** Only show transactions at or before this block height
 
 Optional parameters can be combined as follows ```listtransactions_MP 50 100``` to list the 50 most recent transactions across all addresses in the wallet, skipping the first 100.
+
 Optional parameters can be combined as follows ```listtransactions_MP 99999 0 301000 302000``` to list the 99999 most recent transactions across all addresses in the wallet between blocks 301000 and 302000.
 
 **Examples**

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -786,6 +786,295 @@ bool isCrowdsalePurchase(uint256 txid, string address, int64_t *propertyId = NUL
 return false;
 }
 
+// this function standardizes the RPC output for gettransaction_MP and listtransaction_MP into a central function
+bool populateRPCTransaction(uint256 txid, Object *txobj, int *rc)
+{
+    rc = 0;
+    uint256 hash;
+    hash.SetHex(params[0].get_str());
+
+    CTransaction wtx;
+    uint256 blockHash = 0;
+    if (!GetTransaction(hash, wtx, blockHash, true)) { rc = -3331; return false; }
+       //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction"); rc 3331
+
+    CMPTransaction mp_obj;
+    uint256 wtxid = txid;
+    bool bIsMine;
+    bool isMPTx = false;
+    int nFee = 0;
+    string MPTxType;
+    unsigned int MPTxTypeInt;
+    string selectedAddress;
+    string senderAddress;
+    string refAddress;
+    bool valid;
+    bool showReference = false;
+    uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
+    bool divisible = false;
+    uint64_t amount = 0;
+    string result;
+    uint64_t sell_minfee = 0;
+    unsigned char sell_timelimit = 0;
+    unsigned char sell_subaction = 0;
+    uint64_t sell_btcdesired = 0;
+    int rc=0;
+    bool crowdPurchase = false;
+    int64_t crowdPropertyId = 0;
+    int64_t crowdTokens = 0;
+    int64_t issuerTokens = 0;
+    bool crowdDivisible = false;
+    string crowdName;
+    string propertyName;
+
+    if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash])) { rc = -3332; return false; }
+        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: blockHash is 0"); rc 3332
+
+    CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
+    if (NULL == pBlockIndex) { rc = -3333; return false; }
+        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: pBlockIndex is NULL"); rc 3333
+
+    int blockHeight = pBlockIndex->nHeight;
+    int confirmations =  1 + GetHeight() - pBlockIndex->nHeight;
+    int64_t blockTime = mapBlockIndex[blockHash]->nTime; 
+
+    mp_obj.SetNull();
+    CMPOffer temp_offer;
+
+    // replace initial MP detection with levelDB lookup instead of parse, this is much faster especially in calls like list/search
+    if (p_txlistdb->exists(wtxid))
+        {
+        //transaction is in levelDB, so we can attempt to parse it
+        int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
+        if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
+        {
+            // do we have a non-zero RC, if so it's a payment, handle differently
+            if (0 < parseRC)
+            {
+                // handle as payment TX - this doesn't fit nicely into the kind of output for a MP tx so we'll do this seperately
+                // add generic TX data to the output
+                Object txobj;
+                txobj.push_back(Pair("txid", wtxid.GetHex()));
+                txobj.push_back(Pair("confirmations", confirmations));
+                txobj.push_back(Pair("blocktime", blockTime));
+                txobj.push_back(Pair("type", "DEx Purchase"));
+                // always min one subrecord, grab sender from first sub so we can display in parent as per Adam feedback
+                string tmpBuyer;
+                string tmpSeller;
+                uint64_t tmpVout;
+                uint64_t tmpNValue;
+                uint64_t tmpPropertyId;
+                p_txlistdb->getPurchaseDetails(wtxid,1,&tmpBuyer,&tmpSeller,&tmpVout,&tmpPropertyId,&tmpNValue);
+                txobj.push_back(Pair("sendingaddress", tmpBuyer));
+                // get the details of sub records for payment(s) in the tx and push into an array
+                Array purchases;
+                int numberOfPurchases=p_txlistdb->getNumberOfPurchases(wtxid);
+                if (0<numberOfPurchases)
+                {
+                    for(int purchaseNumber = 1; purchaseNumber <= numberOfPurchases; purchaseNumber++)
+                    {
+                        Object purchaseObj;
+                        string buyer;
+                        string seller;
+                        uint64_t vout;
+                        uint64_t nValue;
+                        p_txlistdb->getPurchaseDetails(wtxid,purchaseNumber,&buyer,&seller,&vout,&propertyId,&nValue);
+                        bIsMine = false;
+                        bIsMine = IsMyAddress(buyer);
+                        if (!bIsMine)
+                        {
+                            bIsMine = IsMyAddress(seller);
+                        }
+                        uint64_t amountPaid = wtx.vout[vout].nValue;
+                        purchaseObj.push_back(Pair("vout", vout));
+                        purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
+                        purchaseObj.push_back(Pair("ismine", bIsMine));
+                        purchaseObj.push_back(Pair("referenceaddress", seller));
+                        purchaseObj.push_back(Pair("propertyid", propertyId));
+                        purchaseObj.push_back(Pair("amountbought", FormatDivisibleMP(nValue)));
+                        purchaseObj.push_back(Pair("valid", true)); //only valid purchases are stored, anything else is regular BTC tx
+                        purchases.push_back(purchaseObj);
+                    }
+                }
+                txobj.push_back(Pair("purchases", purchases));
+                // return the object
+                return txobj;
+            }
+            else
+            {
+                // otherwise RC was 0, a valid MP transaction so far
+                if (0<=mp_obj.step1())
+                {
+                    MPTxType = mp_obj.getTypeString();
+                    MPTxTypeInt = mp_obj.getType();
+                    senderAddress = mp_obj.getSender();
+                    refAddress = mp_obj.getReceiver();
+                    isMPTx = true;
+                    nFee = mp_obj.getFeePaid();
+                    int tmpblock=0;
+                    uint32_t tmptype=0;
+                    uint64_t amountNew=0;
+                    valid=getValidMPTX(wtxid, &tmpblock, &tmptype, &amountNew);
+                    //populate based on type of tx
+                    switch (MPTxTypeInt)
+                    {
+                        case MSC_TYPE_CREATE_PROPERTY_FIXED:
+                            mp_obj.step2_SmartProperty(rc);
+                            if (0 == rc)
+                            {
+                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                amount = getTotalTokens(propertyId);
+                                propertyName = mp_obj.getSPName();
+                            }
+                            break;
+                        case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
+                            mp_obj.step2_SmartProperty(rc);
+                            if (0 == rc)
+                            {
+                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                amount = 0; // crowdsale txs always create zero tokens
+                                propertyName = mp_obj.getSPName();
+                            }
+                            break;
+                            case MSC_TYPE_CREATE_PROPERTY_MANUAL:
+                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                amount = 0; // issuance of a managed token does not create tokens
+                            break;
+                            case MSC_TYPE_SIMPLE_SEND:
+                                if (0 == mp_obj.step2_Value())
+                                {
+                                    propertyId = mp_obj.getCurrency();
+                                    amount = mp_obj.getAmount();
+                                    showReference = true;
+                                    //check crowdsale invest?
+                                    crowdPurchase = isCrowdsalePurchase(wtxid, refAddress, &crowdPropertyId, &crowdTokens, &issuerTokens);
+                                    if (crowdPurchase)
+                                    {
+                                        MPTxType = "Crowdsale Purchase";
+                                        CMPSPInfo::Entry sp;
+                                        if (false == _my_sps->getSP(crowdPropertyId, sp)) { rc = -3334; return false; }
+                                            //throw JSONRPCError(RPC_INVALID_PARAMETER, "Exception: Crowdsale Purchase but Property ID does not exist"); rc 3334
+
+                                        crowdName = sp.name;
+                                        crowdDivisible = sp.isDivisible();
+                                    }
+                                }
+                            break;
+                            case MSC_TYPE_TRADE_OFFER:
+                                if (0 == mp_obj.step2_Value())
+                                {
+                                    propertyId = mp_obj.getCurrency();
+                                    amount = mp_obj.getAmount();
+                                }
+                                if (0 <= mp_obj.interpretPacket(&temp_offer))
+                                {
+                                    sell_minfee = temp_offer.getMinFee();
+                                    sell_timelimit = temp_offer.getBlockTimeLimit();
+                                    sell_subaction = temp_offer.getSubaction();
+                                    sell_btcdesired = temp_offer.getBTCDesiredOriginal();
+                                }
+                                if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
+                            break;
+                            case MSC_TYPE_ACCEPT_OFFER_BTC:
+                                if (0 == mp_obj.step2_Value())
+                                {
+                                    propertyId = mp_obj.getCurrency();
+                                    amount = mp_obj.getAmount();
+                                    showReference = true;
+                                }
+                                if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
+                            break;
+                            case MSC_TYPE_CLOSE_CROWDSALE:
+                                if (0 == mp_obj.step2_Value())
+                                {
+                                    propertyId = mp_obj.getCurrency();
+                                }
+                            break;
+                            case  MSC_TYPE_SEND_TO_OWNERS:
+                                if (0 == mp_obj.step2_Value())
+                                {
+                                    propertyId = mp_obj.getCurrency();
+                                    amount = mp_obj.getAmount();
+                                }
+                            break;
+                        } // end switch
+                        divisible=isPropertyDivisible(propertyId);
+                    }
+                }
+            }
+            else
+            {
+                rc = -3335;
+                return false;
+                //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction but TX exists in levelDB.  This may be a bug."); rc 3335
+            }
+        }
+        else
+        {
+            rc = -3336;
+            return false;
+                //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction"); rc 3336
+        }
+
+        if (isMPTx)
+        {
+            // test sender and reference against ismine to determine which address is ours
+            // if both ours (eg sending to another address in wallet) use reference
+            bIsMine = IsMyAddress(senderAddress);
+            if (!bIsMine)
+            {
+                bIsMine = IsMyAddress(refAddress);
+            }
+            txobj.push_back(Pair("txid", wtxid.GetHex()));
+            txobj.push_back(Pair("sendingaddress", senderAddress));
+            if (showReference) txobj.push_back(Pair("referenceaddress", refAddress));
+            txobj.push_back(Pair("ismine", bIsMine));
+            txobj.push_back(Pair("confirmations", confirmations));
+            txobj.push_back(Pair("fee", ValueFromAmount(nFee)));
+            txobj.push_back(Pair("blocktime", blockTime));
+            txobj.push_back(Pair("type", MPTxType));
+            txobj.push_back(Pair("propertyid", propertyId));
+            if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj.push_back(Pair("propertyname", propertyName));
+            txobj.push_back(Pair("divisible", divisible));
+            if (divisible)
+            {
+                txobj.push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
+            }
+            else
+            {
+                txobj.push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
+            }
+            if (crowdPurchase)
+            {
+                txobj.push_back(Pair("purchasedpropertyid", crowdPropertyId));
+                txobj.push_back(Pair("purchasedpropertyname", crowdName));
+                if (crowdDivisible)
+                {
+                    txobj.push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
+                    txobj.push_back(Pair("issuertokens", FormatDivisibleMP(issuerTokens)));
+                }
+                else
+                {
+                    txobj.push_back(Pair("purchasedtokens", FormatIndivisibleMP(crowdTokens))); //indivisible, push raw 64
+                    txobj.push_back(Pair("issuertokens", FormatIndivisibleMP(issuerTokens)));
+                }
+            }
+            if (MSC_TYPE_TRADE_OFFER == MPTxTypeInt)
+            {
+                txobj.push_back(Pair("feerequired", ValueFromAmount(sell_minfee)));
+                txobj.push_back(Pair("timelimit", sell_timelimit));
+                //for now must mark all v0 sells as new until we find a way to store a subaction for v0 sells
+                if ((1 == sell_subaction) || ((0 == sell_subaction) && (0 < amount))) txobj.push_back(Pair("subaction", "New"));
+                if (2 == sell_subaction) txobj.push_back(Pair("subaction", "Update"));
+                if ((3 == sell_subaction) || ((0 == sell_subaction) && (0 == amount))) txobj.push_back(Pair("subaction", "Cancel"));
+                txobj.push_back(Pair("bitcoindesired", ValueFromAmount(sell_btcdesired)));
+            }
+            txobj.push_back(Pair("valid", valid));
+        }
+    }
+    return true;
+}
+
 // get total tokens for a property
 // optionally counters the number of addresses who own that property: n_owners_total
 int64_t mastercore::getTotalTokens(unsigned int propertyId, int64_t *n_owners_total)
@@ -5475,7 +5764,7 @@ Value gettransaction_MP(const Array& params, bool fHelp)
                         txobj.push_back(Pair("blocktime", blockTime));
                         txobj.push_back(Pair("type", MPTxType));
                         txobj.push_back(Pair("propertyid", propertyId));
-                        if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj.push_back(Pair("propertyname", propertyName));
+   if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj.push_back(Pair("propertyname", propertyName));
                         txobj.push_back(Pair("divisible", divisible));
                         if (divisible)
                         {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -5314,6 +5314,7 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddre
         {
             txobj->push_back(Pair("purchasedpropertyid", crowdPropertyId));
             txobj->push_back(Pair("purchasedpropertyname", crowdName));
+            txobj->push_back(Pair("purchasedpropertydivisible", crowdDivisible));
             if (crowdDivisible)
             {
                 txobj->push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -5026,7 +5026,7 @@ int validity = 0;
 }
 
 // this function standardizes the RPC output for gettransaction_MP and listtransaction_MP into a central function
-int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddress = NULL)
+int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddress = "")
 {
     //uint256 hash;
     //hash.SetHex(params[0].get_str());
@@ -5123,7 +5123,7 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddre
                         {
                             bIsMine = IsMyAddress(seller);
                         }
-                        if (NULL != filterAddress) if ((buyer != filterAddress) && (seller != filterAddress)) return -1; // return negative rc if filtering & no match
+                        if (!filterAddress.empty()) if ((buyer != filterAddress) && (seller != filterAddress)) return -1; // return negative rc if filtering & no match
                         uint64_t amountPaid = wtx.vout[vout].nValue;
                         purchaseObj.push_back(Pair("vout", vout));
                         purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
@@ -5148,7 +5148,7 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddre
                     MPTxTypeInt = mp_obj.getType();
                     senderAddress = mp_obj.getSender();
                     refAddress = mp_obj.getReceiver();
-                    if (NULL != filterAddress) if ((senderAddress != filterAddress) && (refAddress != filterAddress)) return -1; // return negative rc if filtering & no match
+                    if (!filterAddress.empty()) if ((senderAddress != filterAddress) && (refAddress != filterAddress)) return -1; // return negative rc if filtering & no match
                     isMPTx = true;
                     nFee = mp_obj.getFeePaid();
                     int tmpblock=0;
@@ -5293,7 +5293,10 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddre
         txobj->push_back(Pair("blocktime", blockTime));
         txobj->push_back(Pair("type", MPTxType));
         txobj->push_back(Pair("propertyid", propertyId));
-        if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj->push_back(Pair("propertyname", propertyName));
+        if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_MANUAL == MPTxTypeInt))
+        {
+            txobj->push_back(Pair("propertyname", propertyName));
+        }
         txobj->push_back(Pair("divisible", divisible));
         if (divisible)
         {
@@ -5417,16 +5420,16 @@ Value listtransactions_MP(const Array& params, bool fHelp)
     }
 
     int64_t nCount = 10;
-    if (params.size() > 0) nCount = params[1].get_int64();
+    if (params.size() > 1) nCount = params[1].get_int64();
     if (nCount < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
     int64_t nFrom = 0;
-    if (params.size() > 1) nFrom = params[2].get_int64();
+    if (params.size() > 2) nFrom = params[2].get_int64();
     if (nFrom < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative from");
     int64_t nStartBlock = 0;
-    if (params.size() > 2) nStartBlock = params[3].get_int64();
+    if (params.size() > 3) nStartBlock = params[3].get_int64();
     if (nStartBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative start block");
     int64_t nEndBlock = 999999;
-    if (params.size() > 3) nEndBlock = params[4].get_int64();
+    if (params.size() > 4) nEndBlock = params[4].get_int64();
     if (nEndBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
 
     Array response; //prep an array to hold our output

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -5026,7 +5026,7 @@ int validity = 0;
 }
 
 // this function standardizes the RPC output for gettransaction_MP and listtransaction_MP into a central function
-int populateRPCTransactionObject(uint256 txid, Object *txobj)
+int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddress = NULL)
 {
     //uint256 hash;
     //hash.SetHex(params[0].get_str());
@@ -5123,6 +5123,7 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj)
                         {
                             bIsMine = IsMyAddress(seller);
                         }
+                        if (NULL != filterAddress) if ((buyer != filterAddress) && (seller != filterAddress)) return -1; // return negative rc if filtering & no match
                         uint64_t amountPaid = wtx.vout[vout].nValue;
                         purchaseObj.push_back(Pair("vout", vout));
                         purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
@@ -5147,6 +5148,7 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj)
                     MPTxTypeInt = mp_obj.getType();
                     senderAddress = mp_obj.getSender();
                     refAddress = mp_obj.getReceiver();
+                    if (NULL != filterAddress) if ((senderAddress != filterAddress) && (refAddress != filterAddress)) return -1; // return negative rc if filtering & no match
                     isMPTx = true;
                     nFee = mp_obj.getFeePaid();
                     int tmpblock=0;
@@ -5333,6 +5335,8 @@ int populateRPCTransactionObject(uint256 txid, Object *txobj)
 
 Value gettransaction_MP(const Array& params, bool fHelp)
 {
+    // note this call has been refactored to use the singular populateRPCTransactionObject function
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "gettransaction_MP \"txid\"\n"
@@ -5384,8 +5388,8 @@ Value gettransaction_MP(const Array& params, bool fHelp)
 
 Value listtransactions_MP(const Array& params, bool fHelp)
 {
-CWallet *wallet = pwalletMain;
-string sAddress = "";
+    // note this call has been refactored to use the singular populateRPCTransactionObject function
+    // note address filtering has been readded to this call, and searchtransactions_MP has been removed since performance hit no longer an issue
 
     if (fHelp || params.size() > 5)
         throw runtime_error(
@@ -5395,477 +5399,77 @@ string sAddress = "";
             + HelpExampleRpc("listtransactions_MP", "")
         );
 
-        int64_t nCount = 10;
-        if (params.size() > 0) nCount = params[0].get_int64();
-        int64_t nFrom = 0;
-        if (params.size() > 1) nFrom = params[1].get_int64();
-        int64_t nStartBlock = 0;
-        if (params.size() > 2) nStartBlock = params[2].get_int64();
-        int64_t nEndBlock = 999999;
-        if (params.size() > 3) nEndBlock = params[3].get_int64();
+    CWallet *wallet = pwalletMain;
+    string sAddress = "";
+    string addressParam = "";
+    bool addressFilter;
 
-        if (nCount < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
-        if (nFrom < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative from");
-        if (nStartBlock < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative start block");
-        if (nEndBlock < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
-
-        Array response; //prep an array to hold our output
-        CMPTransaction mp_obj;
-
-        LOCK(wallet->cs_wallet);
-        // rewrite to use original listtransactions methodology from core
-        std::list<CAccountingEntry> acentries;
-        CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, "*");
-
-        // iterate backwards until we have nCount items to return:
-        for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
+    //if 0 params consider all addresses in wallet, otherwise first param is filter address
+    addressFilter = false;
+    if (params.size() > 0)
+    {
+        // allow setting "" or "*" to use nCount and nFrom params with all addresses in wallet
+        if ( ("*" != params[0].get_str()) && ("" != params[0].get_str()) )
         {
-            CWalletTx *const pwtx = (*it).second.first;
-            if (pwtx != 0)
-            {
-                uint256 wtxid = pwtx->GetHash();
-                bool isMPTx = false;
-                unsigned int MPTxTypeInt;
-                string MPTxType;
-                string selectedAddress;
-                string senderAddress;
-                string refAddress;
-                bool valid;
-                uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
-                bool divisible;
-                bool showReference = false;
-                uint64_t amount = 0;
-                string result;
-                int confirmations = pwtx->GetDepthInMainChain(); //what about conflicted (<0)? how will we display these?
-                uint256 blockHash = pwtx->hashBlock;
-                if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash])) continue;
-                CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
-                if (NULL == pBlockIndex) continue;
-                int blockHeight = pBlockIndex->nHeight;
-                int64_t blockTime = mapBlockIndex[pwtx->hashBlock]->nTime;
-                int blockIndex = pwtx->nIndex;
-
-                //ignore transactions not between nStartBlock and nEndBlock
-                if ((blockHeight < nStartBlock) || (blockHeight > nEndBlock)) continue;
-
-                bool crowdPurchase = false;
-                int64_t crowdPropertyId = 0;
-                int64_t crowdTokens = 0;
-                bool crowdDivisible = false;
-                string crowdName;
-
-                mp_obj.SetNull();
-                CMPOffer temp_offer;
-
-                //rather than attempt to parse every transaction in the wallet again looking for MP messages let's look at levelDB in the first instance
-                //this should provide a huge speedup for the example provided where the wallet holds 10,000 or 100,000 bitcoin transactions and only one or two
-                //MP messages, meaning we would go through parsing every TX in the wallet looking for our default return (10) MP messages causing a delayed RPC response
-
-                if (p_txlistdb->exists(wtxid))
-                {
-                    if (0 == parseTransaction(true, *pwtx, blockHeight, 0, &mp_obj))
-                    {
-                        // OK, a valid MP transaction so far
-                        if (0<=mp_obj.step1())
-                        {
-                                MPTxType = mp_obj.getTypeString();
-                                MPTxTypeInt = mp_obj.getType();
-                                senderAddress = mp_obj.getSender();
-                                refAddress = mp_obj.getReceiver();
-                                isMPTx = true;
-
-                                int tmpblock=0;
-                                uint32_t tmptype=0;
-                                uint64_t amountNew=0;
-                                valid=getValidMPTX(wtxid, &tmpblock, &tmptype, &amountNew);
-
-                                //populate based on type of tx
-                                switch (MPTxTypeInt)
-                                {
-                                     case MSC_TYPE_CREATE_PROPERTY_FIXED:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = getTotalTokens(propertyId);
-                                     break;
-                                     case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = 0; // crowdsale txs always create zero tokens
-                                     break;
-                                     case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = 0; // issuance of a managed token does not create tokens
-                                     break;
-                                     case MSC_TYPE_SIMPLE_SEND:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                               showReference = true;
-                                               //check crowdsale invest?
-                                               crowdPurchase = isCrowdsalePurchase(wtxid, refAddress, &crowdPropertyId, &crowdTokens);
-                                               if (crowdPurchase)
-                                               {
-                                                  MPTxType = "Crowdsale Purchase";
-                                                  CMPSPInfo::Entry sp;
-                                                  if (false == _my_sps->getSP(crowdPropertyId, sp)) {
-                                                       throw JSONRPCError(RPC_INVALID_PARAMETER, "Exception: Crowdsale Purchase but Property ID does not exist");
-                                                  }
-                                                  crowdName = sp.name;
-                                                  crowdDivisible = sp.isDivisible();
-                                               }
-                                          }
-                                     break;
-                                     case MSC_TYPE_TRADE_OFFER:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                          }
-                                          if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                                     break;
-                                     case MSC_TYPE_ACCEPT_OFFER_BTC:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                               showReference = true;
-                                          }
-                                          if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                                     break;
-                                     case MSC_TYPE_CLOSE_CROWDSALE:
-                                          propertyId = 0; // propertyId of Crowdsale Close
-                                     break;
-                                     case  MSC_TYPE_SEND_TO_OWNERS:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                          }
-                                     break;
-
-                                }
-                                divisible=isPropertyDivisible(propertyId);
-                          }
-                     }
-                }
-
-                // is this a MP transaction? switched to parsing rather than leveldb at Michael's request
-                if (isMPTx)
-                {
-                                // add the transaction object to the array
-                                Object txobj;
-                                txobj.push_back(Pair("txid", wtxid.GetHex()));
-                                txobj.push_back(Pair("sendingaddress", senderAddress));
-                                if (showReference) txobj.push_back(Pair("referenceaddress", refAddress));
-                                txobj.push_back(Pair("confirmations", confirmations));
-                                txobj.push_back(Pair("blocktime", blockTime));
-                                txobj.push_back(Pair("blockindex", blockIndex));
-                                txobj.push_back(Pair("type", MPTxType));
-                                txobj.push_back(Pair("propertyid", propertyId));
-                                txobj.push_back(Pair("divisible", divisible));
-                                if (divisible)
-                                {
-                                        txobj.push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
-                                }
-                                else
-                                {
-                                        txobj.push_back(Pair("amount", amount)); //indivisible, push raw 64
-                                }
-                                if (crowdPurchase)
-                                {
-                                    txobj.push_back(Pair("purchasedpropertyid", crowdPropertyId));
-                                    txobj.push_back(Pair("purchasedpropertyname", crowdName));
-                                    if (crowdDivisible)
-                                    {
-                                        txobj.push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
-                                    }
-                                    else
-                                    {
-                                        txobj.push_back(Pair("purchasedtokens", crowdTokens)); //indivisible, push raw 64
-                                    }
-                                }
-                                txobj.push_back(Pair("valid", valid));
-                                response.push_back(txobj);
-                }
-            }
-            if ((int)response.size() >= (nCount+nFrom)) break; //don't burn time doing more work than we need to
-    }
-
-    // sort array here and cut on nFrom and nCount
-    if (nFrom > (int)response.size())
-        nFrom = response.size();
-    if ((nFrom + nCount) > (int)response.size())
-        nCount = response.size() - nFrom;
-    Array::iterator first = response.begin();
-    std::advance(first, nFrom);
-    Array::iterator last = response.begin();
-    std::advance(last, nFrom+nCount);
-
-    if (last != response.end()) response.erase(last, response.end());
-    if (first != response.begin()) response.erase(response.begin(), first);
-
-    std::reverse(response.begin(), response.end()); // Return oldest to newest
-    return response;   // return response array for JSON serialization
-}
-
-Value searchtransactions_MP(const Array& params, bool fHelp)
-{
-CWallet *wallet = pwalletMain;
-string sAddress = "";
-string addressParam = "";
-bool addressFilter;
-
-    if (fHelp || params.size() > 5)
-        throw runtime_error(
-            "searchtransactions_MP\n" //todo increase verbosity in help
-            "\nSearch wallet history for transactions filtered on address, counts and block boundaries\n"
-            + HelpExampleCli("searchtransactions_MP", "")
-            + HelpExampleRpc("searchtransactions_MP", "")
-        );
-
-        //if 0 params consider all addresses in wallet, otherwise first param is filter address
-        addressFilter = false;
-        if (params.size() > 0)
-        {
-                  // allow setting "" or "*" to use nCount and nFrom params with all addresses in wallet
-                  if ( ("*" != params[0].get_str()) && ("" != params[0].get_str()) )
-                  {
-                  addressParam = params[0].get_str();
-                  addressFilter = true;
-                  }
+            addressParam = params[0].get_str();
+            addressFilter = true;
         }
-
-        int64_t nCount = 10;
-        if (params.size() > 1) nCount = params[1].get_int64();
-        int64_t nFrom = 0;
-        if (params.size() > 2) nFrom = params[2].get_int64();
-        int64_t nStartBlock = 0;
-        if (params.size() > 3) nStartBlock = params[3].get_int64();
-        int64_t nEndBlock = 999999;
-        if (params.size() > 4) nEndBlock = params[4].get_int64();
-
-        if (nCount < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
-        if (nFrom < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative from");
-        if (nStartBlock < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative start block");
-        if (nEndBlock < 0)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
-
-        Array response; //prep an array to hold our output
-        CMPTransaction mp_obj;
-
-        LOCK(wallet->cs_wallet);
-        // rewrite to use original listtransactions methodology from core
-        std::list<CAccountingEntry> acentries;
-        CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, "*");
-
-        // iterate backwards until we have nCount items to return:
-        for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
-        {
-            CWalletTx *const pwtx = (*it).second.first;
-            if (pwtx != 0)
-            {
-                uint256 wtxid = pwtx->GetHash();
-                bool bIsMine;
-                bool isMPTx = false;
-                unsigned int MPTxTypeInt;
-                string MPTxType;
-                string selectedAddress;
-                string senderAddress;
-                string refAddress;
-                bool valid;
-                uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
-                bool divisible;
-                bool showReference = false;
-                uint64_t amount = 0;
-                string result;
-                bool outgoingTransaction = false;
-                int confirmations = pwtx->GetDepthInMainChain(); //what about conflicted (<0)? how will we display these?
-                uint256 blockHash = pwtx->hashBlock;
-                if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash])) continue;
-                CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
-                if (NULL == pBlockIndex) continue;
-                int blockHeight = pBlockIndex->nHeight;
-                int64_t blockTime = mapBlockIndex[pwtx->hashBlock]->nTime;
-                int blockIndex = pwtx->nIndex;
-
-                //ignore transactions not between nStartBlock and nEndBlock
-                if ((blockHeight < nStartBlock) || (blockHeight > nEndBlock)) continue;
-
-                bool crowdPurchase = false;
-                int64_t crowdPropertyId = 0;
-                int64_t crowdTokens = 0;
-                bool crowdDivisible = false;
-                string crowdName;
-
-                mp_obj.SetNull();
-                CMPOffer temp_offer;
-
-                //rather than attempt to parse every transaction in the wallet again looking for MP messages let's look at levelDB in the first instance
-                //this should provide a huge speedup for the example provided where the wallet holds 10,000 or 100,000 bitcoin transactions and only one or two
-                //MP messages, meaning we would go through parsing every TX in the wallet looking for our default return (10) MP messages causing a delayed RPC response
-
-                if (p_txlistdb->exists(wtxid))
-                {
-                    if (0 == parseTransaction(true, *pwtx, blockHeight, 0, &mp_obj))
-                    {
-                        // OK, a valid MP transaction so far
-                        if (0<=mp_obj.step1())
-                        {
-                                MPTxType = mp_obj.getTypeString();
-                                MPTxTypeInt = mp_obj.getType();
-                                senderAddress = mp_obj.getSender();
-                                refAddress = mp_obj.getReceiver();
-                                isMPTx = true;
-
-                                int tmpblock=0;
-                                uint32_t tmptype=0;
-                                uint64_t amountNew=0;
-                                valid=getValidMPTX(wtxid, &tmpblock, &tmptype, &amountNew);
-
-                                //populate based on type of tx
-                                switch (MPTxTypeInt)
-                                {
-                                     case MSC_TYPE_CREATE_PROPERTY_FIXED:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = getTotalTokens(propertyId);
-                                     break;
-                                     case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = 0; // crowdsale txs always create zero tokens
-                                     break;
-                                     case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = 0; // issuance of a managed token does not create tokens
-                                     break;
-                                     case MSC_TYPE_SIMPLE_SEND:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                               showReference = true;
-                                               //check crowdsale invest?
-                                               crowdPurchase = isCrowdsalePurchase(wtxid, refAddress, &crowdPropertyId, &crowdTokens);
-                                               if (crowdPurchase)
-                                               {
-                                                  MPTxType = "Crowdsale Purchase";
-                                                  CMPSPInfo::Entry sp;
-                                                  if (false == _my_sps->getSP(crowdPropertyId, sp)) {
-                                                       throw JSONRPCError(RPC_INVALID_PARAMETER, "Exception: Crowdsale Purchase but Property ID does not exist");
-                                                  }
-                                                  crowdName = sp.name;
-                                                  crowdDivisible = sp.isDivisible();
-                                               }
-                                          }
-                                     break;
-                                     case MSC_TYPE_TRADE_OFFER:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                          }
-                                          if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                                     break;
-                                     case MSC_TYPE_ACCEPT_OFFER_BTC:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                               showReference = true;
-                                          }
-                                          if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                                     break;
-                                     case MSC_TYPE_CLOSE_CROWDSALE:
-                                          propertyId = 0; // propertyId of Crowdsale Close
-                                     break;
-                                     case  MSC_TYPE_SEND_TO_OWNERS:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                          }
-                                     break;
-
-                                }
-                                divisible=isPropertyDivisible(propertyId);
-                          }
-                     }
-                }
-
-                // is this a MP transaction? switched to parsing rather than leveldb at Michael's request
-                if (isMPTx)
-                {
-                        // test sender and reference against ismine to determine which address is ours
-                        // if both ours (eg sending to another address in wallet) use reference
-                        bIsMine = IsMyAddress(senderAddress);
-                        if (bIsMine)
-                        {
-                                selectedAddress=senderAddress;
-                                outgoingTransaction=true;
-                        }
-                        bIsMine = IsMyAddress(refAddress);
-                        if (bIsMine)
-                        {
-                                selectedAddress=refAddress;
-                        }
-
-                        // are we filtering by address, if so compare
-                        if ((!addressFilter) || (senderAddress == addressParam) || (refAddress == addressParam))
-                        {
-                                // add the transaction object to the array
-                                Object txobj;
-                                txobj.push_back(Pair("txid", wtxid.GetHex()));
-                                txobj.push_back(Pair("sendingaddress", senderAddress));
-                                if (showReference) txobj.push_back(Pair("referenceaddress", refAddress));
-                                if (outgoingTransaction)
-                                {
-                                        txobj.push_back(Pair("direction", "out"));
-                                }
-                                else
-                                {
-                                        txobj.push_back(Pair("direction", "in"));
-                                }
-
-                                txobj.push_back(Pair("confirmations", confirmations));
-                                txobj.push_back(Pair("blocktime", blockTime));
-                                txobj.push_back(Pair("blockindex", blockIndex));
-                                txobj.push_back(Pair("type", MPTxType));
-                                txobj.push_back(Pair("propertyid", propertyId));
-                                txobj.push_back(Pair("divisible", divisible));
-                                if (divisible)
-                                {
-                                        txobj.push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
-                                }
-                                else
-                                {
-                                        txobj.push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
-                                }
-                                if (crowdPurchase)
-                                {
-                                    txobj.push_back(Pair("purchasedpropertyid", crowdPropertyId));
-                                    txobj.push_back(Pair("purchasedpropertyname", crowdName));
-                                    if (crowdDivisible)
-                                    {
-                                        txobj.push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
-                                    }
-                                    else
-                                    {
-                                        txobj.push_back(Pair("purchasedtokens", FormatIndivisibleMP(crowdTokens))); //indivisible, push raw 64
-                                    }
-                                }
-                                txobj.push_back(Pair("valid", valid));
-                                response.push_back(txobj);
-                        }
-                }
-            }
-            if ((int)response.size() >= (nCount+nFrom)) break; //don't burn time doing more work than we need to
     }
 
+    int64_t nCount = 10;
+    if (params.size() > 0) nCount = params[1].get_int64();
+    if (nCount < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
+    int64_t nFrom = 0;
+    if (params.size() > 1) nFrom = params[2].get_int64();
+    if (nFrom < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative from");
+    int64_t nStartBlock = 0;
+    if (params.size() > 2) nStartBlock = params[3].get_int64();
+    if (nStartBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative start block");
+    int64_t nEndBlock = 999999;
+    if (params.size() > 3) nEndBlock = params[4].get_int64();
+    if (nEndBlock < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative end block");
+
+    Array response; //prep an array to hold our output
+
+    // rewrite to use original listtransactions methodology from core
+    LOCK(wallet->cs_wallet);
+    std::list<CAccountingEntry> acentries;
+    CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, "*");
+
+    // iterate backwards until we have nCount items to return:
+    for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
+    {
+        CWalletTx *const pwtx = (*it).second.first;
+        if (pwtx != 0)
+        {
+            // get the height of the transaction and check it's within the chosen parameters
+            uint256 blockHash = pwtx->hashBlock;
+            if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash])) continue;
+            CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
+            if (NULL == pBlockIndex) continue;
+            int blockHeight = pBlockIndex->nHeight;
+            if ((blockHeight < nStartBlock) || (blockHeight > nEndBlock)) continue; // ignore it if not within our range
+
+            // populateRPCTransactionObject will throw us a non-0 rc if this isn't a MP transaction, speeds up search by orders of magnitude
+            uint256 hash = pwtx->GetHash();
+            Object txobj;
+
+            // make a request to new RPC populator function to populate a transaction object (if it is a MP transaction)
+            int populateResult = -1;
+            if (addressFilter)
+            {
+                populateResult = populateRPCTransactionObject(hash, &txobj, addressParam); // pass in an address filter
+            }
+            else
+            {
+                populateResult = populateRPCTransactionObject(hash, &txobj); // no address filter
+            }
+            if (0 == populateResult) response.push_back(txobj); // add the transaction object to the response array if we get a 0 rc
+
+            // don't burn time doing more work than we need to
+            if ((int)response.size() >= (nCount+nFrom)) break;
+        }
+    }
     // sort array here and cut on nFrom and nCount
     if (nFrom > (int)response.size())
         nFrom = response.size();
@@ -5879,7 +5483,7 @@ bool addressFilter;
     if (last != response.end()) response.erase(last, response.end());
     if (first != response.begin()) response.erase(response.begin(), first);
 
-    std::reverse(response.begin(), response.end()); // Return oldest to newest
+    std::reverse(response.begin(), response.end()); // return oldest to newest?
     return response;   // return response array for JSON serialization
 }
 

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -786,295 +786,6 @@ bool isCrowdsalePurchase(uint256 txid, string address, int64_t *propertyId = NUL
 return false;
 }
 
-// this function standardizes the RPC output for gettransaction_MP and listtransaction_MP into a central function
-bool populateRPCTransaction(uint256 txid, Object *txobj, int *rc)
-{
-    rc = 0;
-    uint256 hash;
-    hash.SetHex(params[0].get_str());
-
-    CTransaction wtx;
-    uint256 blockHash = 0;
-    if (!GetTransaction(hash, wtx, blockHash, true)) { rc = -3331; return false; }
-       //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction"); rc 3331
-
-    CMPTransaction mp_obj;
-    uint256 wtxid = txid;
-    bool bIsMine;
-    bool isMPTx = false;
-    int nFee = 0;
-    string MPTxType;
-    unsigned int MPTxTypeInt;
-    string selectedAddress;
-    string senderAddress;
-    string refAddress;
-    bool valid;
-    bool showReference = false;
-    uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
-    bool divisible = false;
-    uint64_t amount = 0;
-    string result;
-    uint64_t sell_minfee = 0;
-    unsigned char sell_timelimit = 0;
-    unsigned char sell_subaction = 0;
-    uint64_t sell_btcdesired = 0;
-    int rc=0;
-    bool crowdPurchase = false;
-    int64_t crowdPropertyId = 0;
-    int64_t crowdTokens = 0;
-    int64_t issuerTokens = 0;
-    bool crowdDivisible = false;
-    string crowdName;
-    string propertyName;
-
-    if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash])) { rc = -3332; return false; }
-        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: blockHash is 0"); rc 3332
-
-    CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
-    if (NULL == pBlockIndex) { rc = -3333; return false; }
-        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: pBlockIndex is NULL"); rc 3333
-
-    int blockHeight = pBlockIndex->nHeight;
-    int confirmations =  1 + GetHeight() - pBlockIndex->nHeight;
-    int64_t blockTime = mapBlockIndex[blockHash]->nTime; 
-
-    mp_obj.SetNull();
-    CMPOffer temp_offer;
-
-    // replace initial MP detection with levelDB lookup instead of parse, this is much faster especially in calls like list/search
-    if (p_txlistdb->exists(wtxid))
-        {
-        //transaction is in levelDB, so we can attempt to parse it
-        int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
-        if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
-        {
-            // do we have a non-zero RC, if so it's a payment, handle differently
-            if (0 < parseRC)
-            {
-                // handle as payment TX - this doesn't fit nicely into the kind of output for a MP tx so we'll do this seperately
-                // add generic TX data to the output
-                Object txobj;
-                txobj.push_back(Pair("txid", wtxid.GetHex()));
-                txobj.push_back(Pair("confirmations", confirmations));
-                txobj.push_back(Pair("blocktime", blockTime));
-                txobj.push_back(Pair("type", "DEx Purchase"));
-                // always min one subrecord, grab sender from first sub so we can display in parent as per Adam feedback
-                string tmpBuyer;
-                string tmpSeller;
-                uint64_t tmpVout;
-                uint64_t tmpNValue;
-                uint64_t tmpPropertyId;
-                p_txlistdb->getPurchaseDetails(wtxid,1,&tmpBuyer,&tmpSeller,&tmpVout,&tmpPropertyId,&tmpNValue);
-                txobj.push_back(Pair("sendingaddress", tmpBuyer));
-                // get the details of sub records for payment(s) in the tx and push into an array
-                Array purchases;
-                int numberOfPurchases=p_txlistdb->getNumberOfPurchases(wtxid);
-                if (0<numberOfPurchases)
-                {
-                    for(int purchaseNumber = 1; purchaseNumber <= numberOfPurchases; purchaseNumber++)
-                    {
-                        Object purchaseObj;
-                        string buyer;
-                        string seller;
-                        uint64_t vout;
-                        uint64_t nValue;
-                        p_txlistdb->getPurchaseDetails(wtxid,purchaseNumber,&buyer,&seller,&vout,&propertyId,&nValue);
-                        bIsMine = false;
-                        bIsMine = IsMyAddress(buyer);
-                        if (!bIsMine)
-                        {
-                            bIsMine = IsMyAddress(seller);
-                        }
-                        uint64_t amountPaid = wtx.vout[vout].nValue;
-                        purchaseObj.push_back(Pair("vout", vout));
-                        purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
-                        purchaseObj.push_back(Pair("ismine", bIsMine));
-                        purchaseObj.push_back(Pair("referenceaddress", seller));
-                        purchaseObj.push_back(Pair("propertyid", propertyId));
-                        purchaseObj.push_back(Pair("amountbought", FormatDivisibleMP(nValue)));
-                        purchaseObj.push_back(Pair("valid", true)); //only valid purchases are stored, anything else is regular BTC tx
-                        purchases.push_back(purchaseObj);
-                    }
-                }
-                txobj.push_back(Pair("purchases", purchases));
-                // return the object
-                return txobj;
-            }
-            else
-            {
-                // otherwise RC was 0, a valid MP transaction so far
-                if (0<=mp_obj.step1())
-                {
-                    MPTxType = mp_obj.getTypeString();
-                    MPTxTypeInt = mp_obj.getType();
-                    senderAddress = mp_obj.getSender();
-                    refAddress = mp_obj.getReceiver();
-                    isMPTx = true;
-                    nFee = mp_obj.getFeePaid();
-                    int tmpblock=0;
-                    uint32_t tmptype=0;
-                    uint64_t amountNew=0;
-                    valid=getValidMPTX(wtxid, &tmpblock, &tmptype, &amountNew);
-                    //populate based on type of tx
-                    switch (MPTxTypeInt)
-                    {
-                        case MSC_TYPE_CREATE_PROPERTY_FIXED:
-                            mp_obj.step2_SmartProperty(rc);
-                            if (0 == rc)
-                            {
-                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                amount = getTotalTokens(propertyId);
-                                propertyName = mp_obj.getSPName();
-                            }
-                            break;
-                        case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-                            mp_obj.step2_SmartProperty(rc);
-                            if (0 == rc)
-                            {
-                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                amount = 0; // crowdsale txs always create zero tokens
-                                propertyName = mp_obj.getSPName();
-                            }
-                            break;
-                            case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                amount = 0; // issuance of a managed token does not create tokens
-                            break;
-                            case MSC_TYPE_SIMPLE_SEND:
-                                if (0 == mp_obj.step2_Value())
-                                {
-                                    propertyId = mp_obj.getCurrency();
-                                    amount = mp_obj.getAmount();
-                                    showReference = true;
-                                    //check crowdsale invest?
-                                    crowdPurchase = isCrowdsalePurchase(wtxid, refAddress, &crowdPropertyId, &crowdTokens, &issuerTokens);
-                                    if (crowdPurchase)
-                                    {
-                                        MPTxType = "Crowdsale Purchase";
-                                        CMPSPInfo::Entry sp;
-                                        if (false == _my_sps->getSP(crowdPropertyId, sp)) { rc = -3334; return false; }
-                                            //throw JSONRPCError(RPC_INVALID_PARAMETER, "Exception: Crowdsale Purchase but Property ID does not exist"); rc 3334
-
-                                        crowdName = sp.name;
-                                        crowdDivisible = sp.isDivisible();
-                                    }
-                                }
-                            break;
-                            case MSC_TYPE_TRADE_OFFER:
-                                if (0 == mp_obj.step2_Value())
-                                {
-                                    propertyId = mp_obj.getCurrency();
-                                    amount = mp_obj.getAmount();
-                                }
-                                if (0 <= mp_obj.interpretPacket(&temp_offer))
-                                {
-                                    sell_minfee = temp_offer.getMinFee();
-                                    sell_timelimit = temp_offer.getBlockTimeLimit();
-                                    sell_subaction = temp_offer.getSubaction();
-                                    sell_btcdesired = temp_offer.getBTCDesiredOriginal();
-                                }
-                                if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                            break;
-                            case MSC_TYPE_ACCEPT_OFFER_BTC:
-                                if (0 == mp_obj.step2_Value())
-                                {
-                                    propertyId = mp_obj.getCurrency();
-                                    amount = mp_obj.getAmount();
-                                    showReference = true;
-                                }
-                                if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                            break;
-                            case MSC_TYPE_CLOSE_CROWDSALE:
-                                if (0 == mp_obj.step2_Value())
-                                {
-                                    propertyId = mp_obj.getCurrency();
-                                }
-                            break;
-                            case  MSC_TYPE_SEND_TO_OWNERS:
-                                if (0 == mp_obj.step2_Value())
-                                {
-                                    propertyId = mp_obj.getCurrency();
-                                    amount = mp_obj.getAmount();
-                                }
-                            break;
-                        } // end switch
-                        divisible=isPropertyDivisible(propertyId);
-                    }
-                }
-            }
-            else
-            {
-                rc = -3335;
-                return false;
-                //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction but TX exists in levelDB.  This may be a bug."); rc 3335
-            }
-        }
-        else
-        {
-            rc = -3336;
-            return false;
-                //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction"); rc 3336
-        }
-
-        if (isMPTx)
-        {
-            // test sender and reference against ismine to determine which address is ours
-            // if both ours (eg sending to another address in wallet) use reference
-            bIsMine = IsMyAddress(senderAddress);
-            if (!bIsMine)
-            {
-                bIsMine = IsMyAddress(refAddress);
-            }
-            txobj.push_back(Pair("txid", wtxid.GetHex()));
-            txobj.push_back(Pair("sendingaddress", senderAddress));
-            if (showReference) txobj.push_back(Pair("referenceaddress", refAddress));
-            txobj.push_back(Pair("ismine", bIsMine));
-            txobj.push_back(Pair("confirmations", confirmations));
-            txobj.push_back(Pair("fee", ValueFromAmount(nFee)));
-            txobj.push_back(Pair("blocktime", blockTime));
-            txobj.push_back(Pair("type", MPTxType));
-            txobj.push_back(Pair("propertyid", propertyId));
-            if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj.push_back(Pair("propertyname", propertyName));
-            txobj.push_back(Pair("divisible", divisible));
-            if (divisible)
-            {
-                txobj.push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
-            }
-            else
-            {
-                txobj.push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
-            }
-            if (crowdPurchase)
-            {
-                txobj.push_back(Pair("purchasedpropertyid", crowdPropertyId));
-                txobj.push_back(Pair("purchasedpropertyname", crowdName));
-                if (crowdDivisible)
-                {
-                    txobj.push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
-                    txobj.push_back(Pair("issuertokens", FormatDivisibleMP(issuerTokens)));
-                }
-                else
-                {
-                    txobj.push_back(Pair("purchasedtokens", FormatIndivisibleMP(crowdTokens))); //indivisible, push raw 64
-                    txobj.push_back(Pair("issuertokens", FormatIndivisibleMP(issuerTokens)));
-                }
-            }
-            if (MSC_TYPE_TRADE_OFFER == MPTxTypeInt)
-            {
-                txobj.push_back(Pair("feerequired", ValueFromAmount(sell_minfee)));
-                txobj.push_back(Pair("timelimit", sell_timelimit));
-                //for now must mark all v0 sells as new until we find a way to store a subaction for v0 sells
-                if ((1 == sell_subaction) || ((0 == sell_subaction) && (0 < amount))) txobj.push_back(Pair("subaction", "New"));
-                if (2 == sell_subaction) txobj.push_back(Pair("subaction", "Update"));
-                if ((3 == sell_subaction) || ((0 == sell_subaction) && (0 == amount))) txobj.push_back(Pair("subaction", "Cancel"));
-                txobj.push_back(Pair("bitcoindesired", ValueFromAmount(sell_btcdesired)));
-            }
-            txobj.push_back(Pair("valid", valid));
-        }
-    }
-    return true;
-}
-
 // get total tokens for a property
 // optionally counters the number of addresses who own that property: n_owners_total
 int64_t mastercore::getTotalTokens(unsigned int propertyId, int64_t *n_owners_total)
@@ -5488,12 +5199,300 @@ int validity = 0;
   return true;
 }
 
+// this function standardizes the RPC output for gettransaction_MP and listtransaction_MP into a central function
+bool populateRPCTransactionObject(uint256 txid, Object *txobj, int *frc)
+{
+    frc = 0;
+    //uint256 hash;
+    //hash.SetHex(params[0].get_str());
+
+    CTransaction wtx;
+    uint256 blockHash = 0;
+    if (!GetTransaction(txid, wtx, blockHash, true)) { *frc = -3331; return false; }
+       //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction"); rc 3331
+
+    CMPTransaction mp_obj;
+    uint256 wtxid = txid;
+    bool bIsMine;
+    bool isMPTx = false;
+    int nFee = 0;
+    string MPTxType;
+    unsigned int MPTxTypeInt;
+    string selectedAddress;
+    string senderAddress;
+    string refAddress;
+    bool valid;
+    bool showReference = false;
+    uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
+    bool divisible = false;
+    uint64_t amount = 0;
+    string result;
+    uint64_t sell_minfee = 0;
+    unsigned char sell_timelimit = 0;
+    unsigned char sell_subaction = 0;
+    uint64_t sell_btcdesired = 0;
+    int rc=0;
+    bool crowdPurchase = false;
+    int64_t crowdPropertyId = 0;
+    int64_t crowdTokens = 0;
+    int64_t issuerTokens = 0;
+    bool crowdDivisible = false;
+    string crowdName;
+    string propertyName;
+
+    if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash])) { *frc = -3332; return false; }
+        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: blockHash is 0"); rc 3332
+
+    CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
+    if (NULL == pBlockIndex) { *frc = -3333; return false; }
+        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: pBlockIndex is NULL"); rc 3333
+
+    int blockHeight = pBlockIndex->nHeight;
+    int confirmations =  1 + GetHeight() - pBlockIndex->nHeight;
+    int64_t blockTime = mapBlockIndex[blockHash]->nTime;
+
+    mp_obj.SetNull();
+    CMPOffer temp_offer;
+
+    // replace initial MP detection with levelDB lookup instead of parse, this is much faster especially in calls like list/search
+    if (p_txlistdb->exists(wtxid))
+    {
+        //transaction is in levelDB, so we can attempt to parse it
+        int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
+        if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
+        {
+            // do we have a non-zero RC, if so it's a payment, handle differently
+            if (0 < parseRC)
+            {
+                // handle as payment TX - this doesn't fit nicely into the kind of output for a MP tx so we'll do this seperately
+                // add generic TX data to the output
+                //Object txobj;
+                txobj->push_back(Pair("txid", wtxid.GetHex()));
+                txobj->push_back(Pair("confirmations", confirmations));
+                txobj->push_back(Pair("blocktime", blockTime));
+                txobj->push_back(Pair("type", "DEx Purchase"));
+                // always min one subrecord, grab sender from first sub so we can display in parent as per Adam feedback
+                string tmpBuyer;
+                string tmpSeller;
+                uint64_t tmpVout;
+                uint64_t tmpNValue;
+                uint64_t tmpPropertyId;
+                p_txlistdb->getPurchaseDetails(wtxid,1,&tmpBuyer,&tmpSeller,&tmpVout,&tmpPropertyId,&tmpNValue);
+                txobj->push_back(Pair("sendingaddress", tmpBuyer));
+                // get the details of sub records for payment(s) in the tx and push into an array
+                Array purchases;
+                int numberOfPurchases=p_txlistdb->getNumberOfPurchases(wtxid);
+                if (0<numberOfPurchases)
+                {
+                    for(int purchaseNumber = 1; purchaseNumber <= numberOfPurchases; purchaseNumber++)
+                    {
+                        Object purchaseObj;
+                        string buyer;
+                        string seller;
+                        uint64_t vout;
+                        uint64_t nValue;
+                        p_txlistdb->getPurchaseDetails(wtxid,purchaseNumber,&buyer,&seller,&vout,&propertyId,&nValue);
+                        bIsMine = false;
+                        bIsMine = IsMyAddress(buyer);
+                        if (!bIsMine)
+                        {
+                            bIsMine = IsMyAddress(seller);
+                        }
+                        uint64_t amountPaid = wtx.vout[vout].nValue;
+                        purchaseObj.push_back(Pair("vout", vout));
+                        purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
+                        purchaseObj.push_back(Pair("ismine", bIsMine));
+                        purchaseObj.push_back(Pair("referenceaddress", seller));
+                        purchaseObj.push_back(Pair("propertyid", propertyId));
+                        purchaseObj.push_back(Pair("amountbought", FormatDivisibleMP(nValue)));
+                        purchaseObj.push_back(Pair("valid", true)); //only valid purchases are stored, anything else is regular BTC tx
+                        purchases.push_back(purchaseObj);
+                    }
+                }
+                txobj->push_back(Pair("purchases", purchases));
+                // return the object
+                return txobj;
+            }
+            else
+            {
+                // otherwise RC was 0, a valid MP transaction so far
+                if (0<=mp_obj.step1())
+                {
+                    MPTxType = mp_obj.getTypeString();
+                    MPTxTypeInt = mp_obj.getType();
+                    senderAddress = mp_obj.getSender();
+                    refAddress = mp_obj.getReceiver();
+                    isMPTx = true;
+                    nFee = mp_obj.getFeePaid();
+                    int tmpblock=0;
+                    uint32_t tmptype=0;
+                    uint64_t amountNew=0;
+                    valid=getValidMPTX(wtxid, &tmpblock, &tmptype, &amountNew);
+                    //populate based on type of tx
+                    switch (MPTxTypeInt)
+                    {
+                        case MSC_TYPE_CREATE_PROPERTY_FIXED:
+                            mp_obj.step2_SmartProperty(rc);
+                            if (0 == rc)
+                            {
+                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                amount = getTotalTokens(propertyId);
+                                propertyName = mp_obj.getSPName();
+                            }
+                        break;
+                        case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
+                            mp_obj.step2_SmartProperty(rc);
+                            if (0 == rc)
+                            {
+                                propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                                amount = 0; // crowdsale txs always create zero tokens
+                                propertyName = mp_obj.getSPName();
+                            }
+                        break;
+                        case MSC_TYPE_CREATE_PROPERTY_MANUAL:
+                            propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
+                            amount = 0; // issuance of a managed token does not create tokens
+                        break;
+                        case MSC_TYPE_SIMPLE_SEND:
+                            if (0 == mp_obj.step2_Value())
+                            {
+                                propertyId = mp_obj.getCurrency();
+                                amount = mp_obj.getAmount();
+                                showReference = true;
+                                //check crowdsale invest?
+                                crowdPurchase = isCrowdsalePurchase(wtxid, refAddress, &crowdPropertyId, &crowdTokens, &issuerTokens);
+                                if (crowdPurchase)
+                                {
+                                    MPTxType = "Crowdsale Purchase";
+                                    CMPSPInfo::Entry sp;
+                                    if (false == _my_sps->getSP(crowdPropertyId, sp)) { *frc = -3334; return false; }
+                                        //throw JSONRPCError(RPC_INVALID_PARAMETER, "Exception: Crowdsale Purchase but Property ID does not exist"); rc 3334
+
+                                    crowdName = sp.name;
+                                    crowdDivisible = sp.isDivisible();
+                                }
+                            }
+                        break;
+                        case MSC_TYPE_TRADE_OFFER:
+                            if (0 == mp_obj.step2_Value())
+                            {
+                                propertyId = mp_obj.getCurrency();
+                                amount = mp_obj.getAmount();
+                            }
+                            if (0 <= mp_obj.interpretPacket(&temp_offer))
+                            {
+                                sell_minfee = temp_offer.getMinFee();
+                                sell_timelimit = temp_offer.getBlockTimeLimit();
+                                sell_subaction = temp_offer.getSubaction();
+                                sell_btcdesired = temp_offer.getBTCDesiredOriginal();
+                            }
+                            if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
+                        break;
+                        case MSC_TYPE_ACCEPT_OFFER_BTC:
+                            if (0 == mp_obj.step2_Value())
+                            {
+                                propertyId = mp_obj.getCurrency();
+                                amount = mp_obj.getAmount();
+                                showReference = true;
+                            }
+                            if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
+                        break;
+                        case MSC_TYPE_CLOSE_CROWDSALE:
+                            if (0 == mp_obj.step2_Value())
+                            {
+                                propertyId = mp_obj.getCurrency();
+                            }
+                        break;
+                        case  MSC_TYPE_SEND_TO_OWNERS:
+                            if (0 == mp_obj.step2_Value())
+                            {
+                                propertyId = mp_obj.getCurrency();
+                                amount = mp_obj.getAmount();
+                            }
+                        break;
+                    } // end switch
+                    divisible=isPropertyDivisible(propertyId);
+                } // end step 1 if
+            } // end payment check if
+        } //negative RC check
+        else
+        {
+            *frc = -3335;
+            return false;
+            //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction but TX exists in levelDB.  This may be a bug."); rc 3335
+        }
+    }
+    else
+    {
+        *frc = -3336;
+        return false;
+        //throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction"); rc 3336
+    }
+
+    if (isMPTx)
+    {
+        // test sender and reference against ismine to determine which address is ours
+        // if both ours (eg sending to another address in wallet) use reference
+        bIsMine = IsMyAddress(senderAddress);
+        if (!bIsMine)
+        {
+            bIsMine = IsMyAddress(refAddress);
+        }
+        txobj->push_back(Pair("txid", wtxid.GetHex()));
+        txobj->push_back(Pair("sendingaddress", senderAddress));
+        if (showReference) txobj->push_back(Pair("referenceaddress", refAddress));
+        txobj->push_back(Pair("ismine", bIsMine));
+        txobj->push_back(Pair("confirmations", confirmations));
+        txobj->push_back(Pair("fee", ValueFromAmount(nFee)));
+        txobj->push_back(Pair("blocktime", blockTime));
+        txobj->push_back(Pair("type", MPTxType));
+        txobj->push_back(Pair("propertyid", propertyId));
+        if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj->push_back(Pair("propertyname", propertyName));
+        txobj->push_back(Pair("divisible", divisible));
+        if (divisible)
+        {
+            txobj->push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
+        }
+        else
+        {
+            txobj->push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
+        }
+        if (crowdPurchase)
+        {
+            txobj->push_back(Pair("purchasedpropertyid", crowdPropertyId));
+            txobj->push_back(Pair("purchasedpropertyname", crowdName));
+            if (crowdDivisible)
+            {
+                txobj->push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
+                txobj->push_back(Pair("issuertokens", FormatDivisibleMP(issuerTokens)));
+            }
+            else
+            {
+                txobj->push_back(Pair("purchasedtokens", FormatIndivisibleMP(crowdTokens))); //indivisible, push raw 64
+                txobj->push_back(Pair("issuertokens", FormatIndivisibleMP(issuerTokens)));
+            }
+        }
+        if (MSC_TYPE_TRADE_OFFER == MPTxTypeInt)
+        {
+            txobj->push_back(Pair("feerequired", ValueFromAmount(sell_minfee)));
+            txobj->push_back(Pair("timelimit", sell_timelimit));
+            //for now must mark all v0 sells as new until we find a way to store a subaction for v0 sells
+            if ((1 == sell_subaction) || ((0 == sell_subaction) && (0 < amount))) txobj->push_back(Pair("subaction", "New"));
+            if (2 == sell_subaction) txobj->push_back(Pair("subaction", "Update"));
+            if ((3 == sell_subaction) || ((0 == sell_subaction) && (0 == amount))) txobj->push_back(Pair("subaction", "Cancel"));
+            txobj->push_back(Pair("bitcoindesired", ValueFromAmount(sell_btcdesired)));
+        }
+        txobj->push_back(Pair("valid", valid));
+    }
+    return true;
+}
+
 Value gettransaction_MP(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "gettransaction_MP \"txid\"\n"
-            "\nGet detailed information about in-wallet transaction <txid>\n"
+            "\nGet detailed information about a Master Protocol transaction <txid>\n"
             "\nArguments:\n"
             "1. \"txid\"    (string, required) The transaction id\n"
             "\nResult:\n"
@@ -5527,280 +5526,26 @@ Value gettransaction_MP(const Array& params, bool fHelp)
     hash.SetHex(params[0].get_str());
 
     Object txobj;
+    int frc;
 
-    CTransaction wtx;
-    uint256 blockHash = 0;
-    if (!GetTransaction(hash, wtx, blockHash, true))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+    // make a request to new RPC populator function to populate a transaction object
+    bool populateResult = populateRPCTransactionObject(hash, &txobj, &frc);
 
-    // here begins
-    CMPTransaction mp_obj;
+    // check the response, throw any error codes if false
+    if (!populateResult)
+    {
+        switch (frc)
+        {
+            case -3331: throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+            case -3332: throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: blockHash is 0, is transaction unconfirmed?");
+            case -3333: throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: pBlockIndex is NULL, is transaction unconfirmed?");
+            case -3334: throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: Crowdsale Purchase but Property ID does not exist. This may be a bug.");
+            case -3335: throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction but TX exists in levelDB.  This may be a bug.");
+            case -3336: throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction");
+        }
+    }
 
-                uint256 wtxid = wtx.GetHash();
-                bool bIsMine;
-                bool isMPTx = false;
-                int nFee = 0;
-                string MPTxType;
-                unsigned int MPTxTypeInt;
-                string selectedAddress;
-                string senderAddress;
-                string refAddress;
-                bool valid;
-                bool showReference = false;
-                uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
-                bool divisible = false;
-                uint64_t amount = 0;
-                string result;
-                uint64_t sell_minfee = 0;
-                unsigned char sell_timelimit = 0;
-                unsigned char sell_subaction = 0;
-                uint64_t sell_btcdesired = 0;
-                int rc=0;
-                bool crowdPurchase = false;
-                int64_t crowdPropertyId = 0;
-                int64_t crowdTokens = 0;
-                int64_t issuerTokens = 0;
-                bool crowdDivisible = false;
-                string crowdName;
-                string propertyName;
-
-                if ((0 == blockHash) || (NULL == mapBlockIndex[blockHash]))
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: blockHash is 0");
-                CBlockIndex* pBlockIndex = mapBlockIndex[blockHash];
-                if (NULL == pBlockIndex)
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Exception: pBlockIndex is NULL");
-                int blockHeight = pBlockIndex->nHeight;
-                int confirmations =  1 + GetHeight() - pBlockIndex->nHeight;
-                int64_t blockTime = mapBlockIndex[blockHash]->nTime; 
-
-                mp_obj.SetNull();
-                CMPOffer temp_offer;
-                // replace initial MP detection with levelDB lookup instead of parse, this is much faster especially in calls like list/search
-                if (p_txlistdb->exists(wtxid))
-                {
-                    //transaction is in levelDB, so we can attempt to parse it
-                    int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
-                    if (0 <= parseRC) //negative RC means no MP content/badly encoded TX, we shouldn't see this if TX in levelDB but check for sanity
-                    {
-                        // do we have a non-zero RC, if so it's a payment, handle differently
-                        if (0 < parseRC)
-                        {
-                            // handle as payment TX - this doesn't fit nicely into the kind of output for a MP tx so we'll do this seperately
-                            // add generic TX data to the output
-                            Object txobj;
-                            txobj.push_back(Pair("txid", wtxid.GetHex()));
-                            txobj.push_back(Pair("confirmations", confirmations));
-                            txobj.push_back(Pair("blocktime", blockTime));
-                            txobj.push_back(Pair("type", "DEx Purchase"));
-                            // always min one subrecord, grab sender from first sub so we can display in parent as per Adam feedback
-                            string tmpBuyer;
-                            string tmpSeller;
-                            uint64_t tmpVout;
-                            uint64_t tmpNValue;
-                            uint64_t tmpPropertyId;
-                            p_txlistdb->getPurchaseDetails(wtxid,1,&tmpBuyer,&tmpSeller,&tmpVout,&tmpPropertyId,&tmpNValue);
-                            txobj.push_back(Pair("sendingaddress", tmpBuyer));
-                            // get the details of sub records for payment(s) in the tx and push into an array
-                            Array purchases;
-                            int numberOfPurchases=p_txlistdb->getNumberOfPurchases(wtxid);
-                            if (0<numberOfPurchases)
-                            {
-                                for(int purchaseNumber = 1; purchaseNumber <= numberOfPurchases; purchaseNumber++)
-                                {
-                                     Object purchaseObj;
-                                     string buyer;
-                                     string seller;
-                                     uint64_t vout;
-                                     uint64_t nValue;
-                                     p_txlistdb->getPurchaseDetails(wtxid,purchaseNumber,&buyer,&seller,&vout,&propertyId,&nValue);
-                                     bIsMine = false;
-                                     bIsMine = IsMyAddress(buyer);
-                                     if (!bIsMine)
-                                     {
-                                         bIsMine = IsMyAddress(seller);
-                                     }
-                                     uint64_t amountPaid = wtx.vout[vout].nValue;
-                                     purchaseObj.push_back(Pair("vout", vout));
-                                     purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
-                                     purchaseObj.push_back(Pair("ismine", bIsMine));
-                                     purchaseObj.push_back(Pair("referenceaddress", seller));
-                                     purchaseObj.push_back(Pair("propertyid", propertyId));
-                                     purchaseObj.push_back(Pair("amountbought", FormatDivisibleMP(nValue)));
-                                     purchaseObj.push_back(Pair("valid", true)); //only valid purchases are stored, anything else is regular BTC tx
-                                     purchases.push_back(purchaseObj);
-                                }
-                            }
-                            txobj.push_back(Pair("purchases", purchases));
-                            // return the object
-                            return txobj;
-                        }
-                        else
-                        {
-                            // otherwise RC was 0, a valid MP transaction so far
-                            if (0<=mp_obj.step1())
-                            {
-                                MPTxType = mp_obj.getTypeString();
-                                MPTxTypeInt = mp_obj.getType();
-                                senderAddress = mp_obj.getSender();
-                                refAddress = mp_obj.getReceiver();
-                                isMPTx = true;
-                                nFee = mp_obj.getFeePaid();
-
-                                int tmpblock=0;
-                                uint32_t tmptype=0;
-                                uint64_t amountNew=0;
-                                valid=getValidMPTX(wtxid, &tmpblock, &tmptype, &amountNew);
-                                //populate based on type of tx
-                                switch (MPTxTypeInt)
-                                {
-                                     case MSC_TYPE_CREATE_PROPERTY_FIXED:
-                                          mp_obj.step2_SmartProperty(rc);
-                                          if (0 == rc)
-                                          {
-                                              propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                              amount = getTotalTokens(propertyId);
-                                              propertyName = mp_obj.getSPName();
-                                          }
-                                     break;
-                                     case MSC_TYPE_CREATE_PROPERTY_VARIABLE:
-                                          mp_obj.step2_SmartProperty(rc);
-                                          if (0 == rc)
-                                          {
-                                              propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                              amount = 0; // crowdsale txs always create zero tokens
-                                              propertyName = mp_obj.getSPName();
-                                          }
-                                     break;
-                                     case MSC_TYPE_CREATE_PROPERTY_MANUAL:
-                                          propertyId = _my_sps->findSPByTX(wtxid); // propertyId of created property (if valid)
-                                          amount = 0; // issuance of a managed token does not create tokens
-                                     break;
-                                     case MSC_TYPE_SIMPLE_SEND:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                               showReference = true;
-                                               //check crowdsale invest?
-                                               crowdPurchase = isCrowdsalePurchase(wtxid, refAddress, &crowdPropertyId, &crowdTokens, &issuerTokens);
-                                               if (crowdPurchase)
-                                               {
-                                                  MPTxType = "Crowdsale Purchase";
-                                                  CMPSPInfo::Entry sp;
-                                                  if (false == _my_sps->getSP(crowdPropertyId, sp)) {
-                                                       throw JSONRPCError(RPC_INVALID_PARAMETER, "Exception: Crowdsale Purchase but Property ID does not exist");
-                                                  }
-                                                  crowdName = sp.name;
-                                                  crowdDivisible = sp.isDivisible();
-                                               } 
-                                          }
-                                     break;
-                                     case MSC_TYPE_TRADE_OFFER:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                          }
-                                          if (0 <= mp_obj.interpretPacket(&temp_offer))
-                                          {
-                                               sell_minfee = temp_offer.getMinFee();
-                                               sell_timelimit = temp_offer.getBlockTimeLimit();
-                                               sell_subaction = temp_offer.getSubaction();
-                                               sell_btcdesired = temp_offer.getBTCDesiredOriginal();
-                                          }
-                                          if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                                     break;
-                                     case MSC_TYPE_ACCEPT_OFFER_BTC:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                               showReference = true;
-                                          }
-                                          if ((valid) && (amountNew>0)) amount=amountNew; //amount has been amended, update
-                                     break;
-                                     case MSC_TYPE_CLOSE_CROWDSALE:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                          }
-                                     break;
-                                     case  MSC_TYPE_SEND_TO_OWNERS:
-                                          if (0 == mp_obj.step2_Value())
-                                          {
-                                               propertyId = mp_obj.getCurrency();
-                                               amount = mp_obj.getAmount();
-                                          }
-                                     break;
-                                } // end switch 
-                            divisible=isPropertyDivisible(propertyId);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction but TX exists in levelDB.  This may be a bug, please report to the developers.");
-                    }
-                }
-                else
-                {
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction");
-                }
-                if (isMPTx)
-                {
-                        // test sender and reference against ismine to determine which address is ours
-                        // if both ours (eg sending to another address in wallet) use reference
-                        bIsMine = IsMyAddress(senderAddress);
-                        if (!bIsMine)
-                        {
-                                bIsMine = IsMyAddress(refAddress);
-                        }
-                        txobj.push_back(Pair("txid", wtxid.GetHex()));
-                        txobj.push_back(Pair("sendingaddress", senderAddress));
-                        if (showReference) txobj.push_back(Pair("referenceaddress", refAddress));
-                        txobj.push_back(Pair("ismine", bIsMine));
-                        txobj.push_back(Pair("confirmations", confirmations));
-                        txobj.push_back(Pair("fee", ValueFromAmount(nFee)));
-                        txobj.push_back(Pair("blocktime", blockTime));
-                        txobj.push_back(Pair("type", MPTxType));
-                        txobj.push_back(Pair("propertyid", propertyId));
-   if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt)) txobj.push_back(Pair("propertyname", propertyName));
-                        txobj.push_back(Pair("divisible", divisible));
-                        if (divisible)
-                        {
-                                txobj.push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
-                        }
-                        else
-                        {
-                                txobj.push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
-                        }
-                        if (crowdPurchase)
-                        {
-                                txobj.push_back(Pair("purchasedpropertyid", crowdPropertyId));
-                                txobj.push_back(Pair("purchasedpropertyname", crowdName));
-                                if (crowdDivisible)
-                                {
-                                     txobj.push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
-                                     txobj.push_back(Pair("issuertokens", FormatDivisibleMP(issuerTokens)));
-                                }
-                                else
-                                {
-                                     txobj.push_back(Pair("purchasedtokens", FormatIndivisibleMP(crowdTokens))); //indivisible, push raw 64
-                                     txobj.push_back(Pair("issuertokens", FormatIndivisibleMP(issuerTokens)));
-                                }
-                        }
-                        if (MSC_TYPE_TRADE_OFFER == MPTxTypeInt)
-                        {
-                        txobj.push_back(Pair("feerequired", ValueFromAmount(sell_minfee)));
-                        txobj.push_back(Pair("timelimit", sell_timelimit));
-                        //for now must mark all v0 sells as new until we find a way to store a subaction for v0 sells
-                        if ((1 == sell_subaction) || ((0 == sell_subaction) && (0 < amount))) txobj.push_back(Pair("subaction", "New"));
-                        if (2 == sell_subaction) txobj.push_back(Pair("subaction", "Update"));
-                        if ((3 == sell_subaction) || ((0 == sell_subaction) && (0 == amount))) txobj.push_back(Pair("subaction", "Cancel"));
-                        txobj.push_back(Pair("bitcoindesired", ValueFromAmount(sell_btcdesired)));
-                        }
-                        txobj.push_back(Pair("valid", valid));
-                }
+    // everything seems ok, return the object
     return txobj;
 }
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -184,14 +184,10 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "getbalance_MP"          && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "sendtoowners_MP"        && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "getproperty_MP"         && n > 0) ConvertTo<int64_t>(params[0]);
-    if (strMethod == "listtransactions_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
-    if (strMethod == "listtransactions_MP"    && n > 1) ConvertTo<int64_t>(params[1]);
-    if (strMethod == "listtransactions_MP"    && n > 2) ConvertTo<int64_t>(params[2]);
-    if (strMethod == "listtransactions_MP"    && n > 3) ConvertTo<int64_t>(params[3]);
-    if (strMethod == "searchtransactions_MP"    && n > 1) ConvertTo<int64_t>(params[1]);
-    if (strMethod == "searchtransactions_MP"    && n > 2) ConvertTo<int64_t>(params[2]);
-    if (strMethod == "searchtransactions_MP"    && n > 3) ConvertTo<int64_t>(params[3]);
-    if (strMethod == "searchtransactions_MP"    && n > 4) ConvertTo<int64_t>(params[4]);
+    if (strMethod == "listtransactions_MP"    && n > 1) ConvertTo<int64_t>(params[0]);
+    if (strMethod == "listtransactions_MP"    && n > 2) ConvertTo<int64_t>(params[1]);
+    if (strMethod == "listtransactions_MP"    && n > 3) ConvertTo<int64_t>(params[2]);
+    if (strMethod == "listtransactions_MP"    && n > 4) ConvertTo<int64_t>(params[3]);
     if (strMethod == "getallbalancesforid_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "listblocktransactions_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -184,10 +184,10 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "getbalance_MP"          && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "sendtoowners_MP"        && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "getproperty_MP"         && n > 0) ConvertTo<int64_t>(params[0]);
-    if (strMethod == "listtransactions_MP"    && n > 1) ConvertTo<int64_t>(params[0]);
-    if (strMethod == "listtransactions_MP"    && n > 2) ConvertTo<int64_t>(params[1]);
-    if (strMethod == "listtransactions_MP"    && n > 3) ConvertTo<int64_t>(params[2]);
-    if (strMethod == "listtransactions_MP"    && n > 4) ConvertTo<int64_t>(params[3]);
+    if (strMethod == "listtransactions_MP"    && n > 1) ConvertTo<int64_t>(params[1]);
+    if (strMethod == "listtransactions_MP"    && n > 2) ConvertTo<int64_t>(params[2]);
+    if (strMethod == "listtransactions_MP"    && n > 3) ConvertTo<int64_t>(params[3]);
+    if (strMethod == "listtransactions_MP"    && n > 4) ConvertTo<int64_t>(params[4]);
     if (strMethod == "getallbalancesforid_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "listblocktransactions_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -322,7 +322,6 @@ static const CRPCCommand vRPCCommands[] =
     { "send_MP",                &send_MP,                false,     false,      true },
     { "gettransaction_MP",      &gettransaction_MP,      false,     false,      true },
     { "listtransactions_MP",    &listtransactions_MP,    false,     false,      true },
-    { "searchtransactions_MP",  &searchtransactions_MP,  false,     false,      true },
     { "getproperty_MP",         &getproperty_MP,         false,     false,      true },
     { "listproperties_MP",      &listproperties_MP,      false,     false,      true },
     { "getcrowdsale_MP",        &getcrowdsale_MP,        false,     false,      true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -193,7 +193,6 @@ extern json_spirit::Value getallbalancesforaddress_MP(const json_spirit::Array& 
 extern json_spirit::Value getactivedexsells_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
 extern json_spirit::Value gettransaction_MP(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listtransactions_MP(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value searchtransactions_MP(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listblocktransactions_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
 extern json_spirit::Value getbestblockhash(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getdifficulty(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This PR is focused on streamlining the RPC code and adding manual issuance/grant/revoke support.  
It primarily serves the following purposes:
- Remove multiple sets of duplicated & differing code across RPC transaction functions
- Refactor transactions into one single function (populateRPCTransactionObject) to achieve:
  - Introduce concept of a singular standardized 'transaction object' in the RPC layer
  - Singular codebase to modify/add transaction types to RPC layer
  - Standardize the output of gettransaction_MP, listtransactions_MP and any future calls that show transactions
- Add support for manual issuance, grant and revoke transaction types
- Remove redundant searchtransactions_MP function 
- Reapply address filtering to listtransactions_MP now using levelDB
- Patch unexpected subaction bytes as subaction 0 (to handle v0 packets)

Thanks
Z
