### PR TITLE
Fix: std::string fName = ...c_str(); -> ...string();

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1824,7 +1824,7 @@ static int load_most_relevant_state()
       continue;
     }
 
-    std::string fName = (*--dIter->path().end()).c_str();
+    std::string fName = (*--dIter->path().end()).string();
     std::vector<std::string> vstr;
     boost::split(vstr, fName, boost::is_any_of("-."), token_compress_on);
     if (  vstr.size() == 3 &&


### PR DESCRIPTION
This fixes:

mastercore.cpp: In function ‘int load_most_relevant_state()’:
mastercore.cpp:1827:56: error: conversion from ‘const value_type\* {aka const wchar_t*}’ to non-scalar type ‘std::string {aka std::basic_string<char>}’ requested
