### PR TITLE
Start to avoid using globally defined namespaces

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2729,7 +2729,7 @@ int CMPTxList::getNumberOfPurchases(const uint256 txid)
     int numberOfPurchases = 0;
     std::vector<std::string> vstr;
     string strValue;
-    Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
+    leveldb::Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
     if (status.ok())
     {
         // parse the string returned
@@ -2748,7 +2748,7 @@ bool CMPTxList::getPurchaseDetails(const uint256 txid, int purchaseNumber, strin
     if (!pdb) return 0;
     std::vector<std::string> vstr;
     string strValue;
-    Status status = pdb->Get(readoptions, txid.ToString()+"-"+to_string(purchaseNumber), &strValue);
+    leveldb::Status status = pdb->Get(readoptions, txid.ToString()+"-"+to_string(purchaseNumber), &strValue);
     if (status.ok())
     {
         // parse the string returned
@@ -2787,7 +2787,7 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
            //retrieve old numberOfPayments
            std::vector<std::string> vstr;
            string strValue;
-           Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
+           leveldb::Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
            if (status.ok())
            {
                // parse the string returned
@@ -2806,7 +2806,7 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
        // Step 3 - Create new/update master record for payment tx in TXList
        const string key = txid.ToString();
        const string value = strprintf("%u:%d:%u:%lu", fValid ? 1:0, nBlock, type, numberOfPayments); 
-       Status status;
+       leveldb::Status status;
        fprintf(mp_fp, "DEXPAYDEBUG : Writing master record %s(%s, valid=%s, block= %d, type= %d, number of payments= %lu)\n", __FUNCTION__, txid.ToString().c_str(), fValid ? "YES":"NO", nBlock, type, numberOfPayments);
        if (pdb)
        {
@@ -2818,7 +2818,7 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
        const string txidStr = txid.ToString();
        const string subKey = STR_PAYMENT_SUBKEY_TXID_PAYMENT_COMBO(txidStr);
        const string subValue = strprintf("%d:%s:%s:%d:%lu", vout, buyer, seller, propertyId, nValue);
-       Status subStatus;
+       leveldb::Status subStatus;
        fprintf(mp_fp, "DEXPAYDEBUG : Writing sub-record %s with value %s\n", subKey.c_str(), subValue.c_str());
        if (pdb)
        {
@@ -2833,7 +2833,7 @@ void CMPTxList::recordTX(const uint256 &txid, bool fValid, int nBlock, unsigned 
 
 const string key = txid.ToString();
 const string value = strprintf("%u:%d:%u:%lu", fValid ? 1:0, nBlock, type, nValue);
-Status status;
+leveldb::Status status;
 
   fprintf(mp_fp, "%s(%s, valid=%s, block= %d, type= %d, value= %lu)\n",
    __FUNCTION__, txid.ToString().c_str(), fValid ? "YES":"NO", nBlock, type, nValue);
@@ -2851,7 +2851,7 @@ bool CMPTxList::exists(const uint256 &txid)
   if (!pdb) return false;
 
 string strValue;
-Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
+leveldb::Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
 
   if (!status.ok())
   {
@@ -2863,7 +2863,7 @@ Status status = pdb->Get(readoptions, txid.ToString(), &strValue);
 
 bool CMPTxList::getTX(const uint256 &txid, string &value)
 {
-Status status = pdb->Get(readoptions, txid.ToString(), &value);
+leveldb::Status status = pdb->Get(readoptions, txid.ToString(), &value);
 
   ++nRead;
 
@@ -2883,11 +2883,11 @@ void CMPTxList::printStats()
 void CMPTxList::printAll()
 {
 int count = 0;
-Slice skey, svalue;
+leveldb::Slice skey, svalue;
 
   readoptions.fill_cache = false;
 
-  Iterator* it = pdb->NewIterator(readoptions);
+  leveldb::Iterator* it = pdb->NewIterator(readoptions);
 
   for(it->SeekToFirst(); it->Valid(); it->Next())
   {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1507,7 +1507,7 @@ const int max_block = GetHeight();
 int input_msc_balances_string(const string &s)
 {
   std::vector<std::string> addrData;
-  boost::split(addrData, s, boost::is_any_of("="), token_compress_on);
+  boost::split(addrData, s, boost::is_any_of("="), boost::token_compress_on);
   if (addrData.size() != 2) {
     return -1;
   }
@@ -1516,7 +1516,7 @@ int input_msc_balances_string(const string &s)
 
   // split the tuples of currencies
   std::vector<std::string> vCurrencies;
-  boost::split(vCurrencies, addrData[1], boost::is_any_of(";"), token_compress_on);
+  boost::split(vCurrencies, addrData[1], boost::is_any_of(";"), boost::token_compress_on);
 
   std::vector<std::string>::const_iterator iter;
   for (iter = vCurrencies.begin(); iter != vCurrencies.end(); ++iter) {
@@ -1525,7 +1525,7 @@ int input_msc_balances_string(const string &s)
     }
 
     std::vector<std::string> curData;
-    boost::split(curData, *iter, boost::is_any_of(","), token_compress_on);
+    boost::split(curData, *iter, boost::is_any_of(","), boost::token_compress_on);
     if (curData.size() < 1) {
       // malformed currency entry
        return -1;
@@ -1571,7 +1571,7 @@ int input_mp_offers_string(const string &s)
   unsigned int curr;
   unsigned char blocktimelimit;
   std::vector<std::string> vstr;
-  boost::split(vstr, s, boost::is_any_of(" ,="), token_compress_on);
+  boost::split(vstr, s, boost::is_any_of(" ,="), boost::token_compress_on);
   string sellerAddr;
   string txidStr;
   int i = 0;
@@ -1606,7 +1606,7 @@ int input_mp_accepts_string(const string &s)
   int nBlock;
   unsigned char blocktimelimit;
   std::vector<std::string> vstr;
-  boost::split(vstr, s, boost::is_any_of(" ,="), token_compress_on);
+  boost::split(vstr, s, boost::is_any_of(" ,="), boost::token_compress_on);
   uint64_t amountRemaining, amountOriginal, offerOriginal, btcDesired;
   unsigned int curr;
   string sellerAddr, buyerAddr, txidStr;
@@ -1640,7 +1640,7 @@ int input_globals_state_string(const string &s)
   uint64_t exodusPrev;
   unsigned int nextSPID, nextTestSPID;
   std::vector<std::string> vstr;
-  boost::split(vstr, s, boost::is_any_of(" ,="), token_compress_on);
+  boost::split(vstr, s, boost::is_any_of(" ,="), boost::token_compress_on);
   if (3 != vstr.size()) return -1;
 
   int i = 0;
@@ -1667,7 +1667,7 @@ int input_mp_crowdsale_string(const string &s)
   uint64_t i_created;
 
   std::vector<std::string> vstr;
-  boost::split(vstr, s, boost::is_any_of(" ,"), token_compress_on);
+  boost::split(vstr, s, boost::is_any_of(" ,"), boost::token_compress_on);
   unsigned int i = 0;
 
   if (9 > vstr.size()) return -1;
@@ -1687,11 +1687,11 @@ int input_mp_crowdsale_string(const string &s)
   // load the remaining as database pairs
   while (i < vstr.size()) {
     std::vector<std::string> entryData;
-    boost::split(entryData, vstr[i++], boost::is_any_of("="), token_compress_on);
+    boost::split(entryData, vstr[i++], boost::is_any_of("="), boost::token_compress_on);
     if ( 2 != entryData.size()) return -1;
 
     std::vector<std::string> valueData;
-    boost::split(valueData, entryData[1], boost::is_any_of(";"), token_compress_on);
+    boost::split(valueData, entryData[1], boost::is_any_of(";"), boost::token_compress_on);
 
     std::vector<uint64_t> vals;
     std::vector<std::string>::const_iterator iter;
@@ -1869,7 +1869,7 @@ static int load_most_relevant_state()
 
     std::string fName = (*--dIter->path().end()).string();
     std::vector<std::string> vstr;
-    boost::split(vstr, fName, boost::is_any_of("-."), token_compress_on);
+    boost::split(vstr, fName, boost::is_any_of("-."), boost::token_compress_on);
     if (  vstr.size() == 3 &&
           boost::equals(vstr[2], "dat")) {
       uint256 blockHash;
@@ -1978,7 +1978,7 @@ static int write_mp_offers(ofstream &file, SHA256_CTX *shaCtx)
   for (iter = my_offers.begin(); iter != my_offers.end(); ++iter) {
     // decompose the key for address
     std::vector<std::string> vstr;
-    boost::split(vstr, (*iter).first, boost::is_any_of("-"), token_compress_on);
+    boost::split(vstr, (*iter).first, boost::is_any_of("-"), boost::token_compress_on);
     CMPOffer const &offer = (*iter).second;
     offer.saveOffer(file, shaCtx, vstr[0]);
   }
@@ -1993,7 +1993,7 @@ static int write_mp_accepts(ofstream &file, SHA256_CTX *shaCtx)
   for (iter = my_accepts.begin(); iter != my_accepts.end(); ++iter) {
     // decompose the key for address
     std::vector<std::string> vstr;
-    boost::split(vstr, (*iter).first, boost::is_any_of("-+"), token_compress_on);
+    boost::split(vstr, (*iter).first, boost::is_any_of("-+"), boost::token_compress_on);
     CMPAccept const &accept = (*iter).second;
     accept.saveAccept(file, shaCtx, vstr[0], vstr[1]);
   }
@@ -2105,7 +2105,7 @@ static void prune_state_files( CBlockIndex const *topIndex )
     }
 
     std::vector<std::string> vstr;
-    boost::split(vstr, fName, boost::is_any_of("-."), token_compress_on);
+    boost::split(vstr, fName, boost::is_any_of("-."), boost::token_compress_on);
     if (  vstr.size() == 3 &&
           is_state_prefix(vstr[0]) &&
           boost::equals(vstr[2], "dat")) {
@@ -2733,7 +2733,7 @@ int CMPTxList::getNumberOfPurchases(const uint256 txid)
     if (status.ok())
     {
         // parse the string returned
-        boost::split(vstr, strValue, boost::is_any_of(":"), token_compress_on);
+        boost::split(vstr, strValue, boost::is_any_of(":"), boost::token_compress_on);
         // obtain the number of purchases
         if (4 <= vstr.size())
         {
@@ -2748,11 +2748,11 @@ bool CMPTxList::getPurchaseDetails(const uint256 txid, int purchaseNumber, strin
     if (!pdb) return 0;
     std::vector<std::string> vstr;
     string strValue;
-    leveldb::Status status = pdb->Get(readoptions, txid.ToString()+"-"+to_string(purchaseNumber), &strValue);
+    leveldb::Status status = pdb->Get(readoptions, txid.ToString()+"-"+boost::to_string(purchaseNumber), &strValue);
     if (status.ok())
     {
         // parse the string returned
-        boost::split(vstr, strValue, boost::is_any_of(":"), token_compress_on);
+        boost::split(vstr, strValue, boost::is_any_of(":"), boost::token_compress_on);
         // obtain the requisite details
         if (5 == vstr.size())
         {
@@ -2791,7 +2791,7 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
            if (status.ok())
            {
                // parse the string returned
-               boost::split(vstr, strValue, boost::is_any_of(":"), token_compress_on);
+               boost::split(vstr, strValue, boost::is_any_of(":"), boost::token_compress_on);
 
                // obtain the existing number of payments
                if (4 <= vstr.size())
@@ -2925,7 +2925,7 @@ unsigned int n_found = 0;
     string strvalue = it->value().ToString();
 
     // parse the string returned, find the validity flag/bit & other parameters
-    boost::split(vstr, strvalue, boost::is_any_of(":"), token_compress_on);
+    boost::split(vstr, strvalue, boost::is_any_of(":"), boost::token_compress_on);
 
     // only care about the block number/height here
     if (2 <= vstr.size())
@@ -2978,7 +2978,7 @@ int validity = 0;
 
   // parse the string returned, find the validity flag/bit & other parameters
   std::vector<std::string> vstr;
-  boost::split(vstr, result, boost::is_any_of(":"), token_compress_on);
+  boost::split(vstr, result, boost::is_any_of(":"), boost::token_compress_on);
 
   fprintf(mp_fp, "%s() size=%lu : %s\n", __FUNCTION__, vstr.size(), result.c_str());
 

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -474,7 +474,7 @@ AcceptMap::iterator my_it = my_accepts.begin();
 
       // extract the seller, buyer & currency from the Key
       std::vector<std::string> vstr;
-      boost::split(vstr, my_it->first, boost::is_any_of("-+"), token_compress_on);
+      boost::split(vstr, my_it->first, boost::is_any_of("-+"), boost::token_compress_on);
       string seller = vstr[0];
       int currency = atoi(vstr[1]);
       string buyer = vstr[2];

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -33,10 +33,6 @@
 
 #include <openssl/sha.h>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
-using boost::multiprecision::int128_t;
-using boost::multiprecision::cpp_int;
 using namespace std;
 using namespace boost;
 using namespace boost::assign;

--- a/src/mastercore_sp.cpp
+++ b/src/mastercore_sp.cpp
@@ -146,7 +146,7 @@ bool CMPSPInfo::getSP(unsigned int spid, Entry &info)
 
     // parse the encoded json, failing if it doesnt parse or is an object
     Value spInfoVal;
-    if (false == read_string(spInfoStr, spInfoVal) || spInfoVal.type() != obj_type ) {
+    if (false == json_spirit::read_string(spInfoStr, spInfoVal) || spInfoVal.type() != json_spirit::obj_type) {
       return false;
     }
 
@@ -203,7 +203,7 @@ int CMPSPInfo::popBlock(uint256 const &block_hash)
     for (iter->Seek("sp-"); iter->Valid() && iter->key().starts_with("sp-"); iter->Next()) {
       // parse the encoded json, failing if it doesnt parse or is an object
       Value spInfoVal;
-      if (read_string(iter->value().ToString(), spInfoVal) && spInfoVal.type() == obj_type ) {
+      if (json_spirit::read_string(iter->value().ToString(), spInfoVal) && spInfoVal.type() == json_spirit::obj_type) {
         Entry info;
         info.fromJSON(spInfoVal.get_obj());
         if (info.update_block == block_hash) {

--- a/src/mastercore_sp.cpp
+++ b/src/mastercore_sp.cpp
@@ -216,7 +216,7 @@ int CMPSPInfo::popBlock(uint256 const &block_hash)
           } else {
             std::vector<std::string> vstr;
             std::string key = iter->key().ToString();
-            boost::split(vstr, key, boost::is_any_of("-"), token_compress_on);
+            boost::split(vstr, key, boost::is_any_of("-"), boost::token_compress_on);
             unsigned int propertyID = boost::lexical_cast<unsigned int>(vstr[1]);
 
             string spPrevKey = (boost::format("blk-%s:sp-%d") % info.update_block.ToString() % propertyID).str();

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -369,7 +369,7 @@ public:
       if (iter->key().starts_with("sp-")) {
         std::vector<std::string> vstr;
         std::string key = iter->key().ToString();
-        boost::split(vstr, key, boost::is_any_of("-"), token_compress_on);
+        boost::split(vstr, key, boost::is_any_of("-"), boost::token_compress_on);
 
         printf("%10s => ", vstr[1].c_str());
 

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -375,7 +375,7 @@ public:
 
         // parse the encoded json, failing if it doesnt parse or is an object
         Value spInfoVal;
-        if (read_string(iter->value().ToString(), spInfoVal) && spInfoVal.type() == obj_type ) {
+        if (json_spirit::read_string(iter->value().ToString(), spInfoVal) && spInfoVal.type() == json_spirit::obj_type) {
           Entry info;
           info.fromJSON(spInfoVal.get_obj());
           info.print();

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -33,10 +33,6 @@
 
 #include <openssl/sha.h>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
-using boost::multiprecision::int128_t;
-using boost::multiprecision::cpp_int;
 using namespace std;
 using namespace boost;
 using namespace boost::assign;


### PR DESCRIPTION
The basic idea: use "uncommon" namespaces inline instead of globally.

This PR is rather tolerant and does not remove global usings, but I think untangling dependencies etc. would be the next step.

The following are available as well - each of them for a specific namespace, but I felt like this would be an overkill to begin with:
- std: [mcore-namespace-std](https://github.com/dexX7/bitcoin/compare/mastercoin-MSC:mscore-0.0.8...mcore-namespace-std)
- json_spirit: [mcore-namespace-json_spirit](https://github.com/dexX7/bitcoin/compare/mastercoin-MSC:mscore-0.0.8...mcore-namespace-json_spirit)
- boost: [mcore-namespace-boost](https://github.com/dexX7/bitcoin/compare/mastercoin-MSC:mscore-0.0.8...mcore-namespace-boost)
- leveldb: [mcore-namespace-leveldb](https://github.com/dexX7/bitcoin/compare/mastercoin-MSC:mscore-0.0.8...mcore-namespace-leveldb)

What I'd like to avoid. mixed use of global/local namespacing. E.g. `std::string` sometimes, and sometimes only `string`.
