### PR TITLE
Fix, workaround for maybe uninitialized variables

### DIFF
--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1507,15 +1507,15 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
 
     CMPTransaction mp_obj;
     uint256 wtxid = txid;
-    bool bIsMine;
+    bool bIsMine = false;
     bool isMPTx = false;
-    int nFee = 0;
+    uint64_t nFee = 0;
     string MPTxType;
     unsigned int MPTxTypeInt;
     string selectedAddress;
     string senderAddress;
     string refAddress;
-    bool valid;
+    bool valid = false;
     bool showReference = false;
     uint64_t propertyId = 0;  //using 64 instead of 32 here as json::sprint chokes on 32 - research why
     bool divisible = false;
@@ -1784,6 +1784,10 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
                     } // end switch
                     divisible=isPropertyDivisible(propertyId);
                 } // end step 1 if
+                else
+                {
+                    return -3336; // "Not a Master Protocol transaction"
+                }
             } // end payment check if
         } //negative RC check
         else


### PR DESCRIPTION
Warnings addressed:

mastercore_rpc.cpp:1515:10: warning: ‘valid’ may be used uninitialized
in this function [-Wmaybe-uninitialized]
mastercore_rpc.cpp:1845:9: warning: ‘MPTxTypeInt’ may be used
uninitialized in this function [-Wmaybe-uninitialized]

I'm on another PR that aims to collect constants etc., so please don't
mind the #define..
