### PR TITLE
WIP: Extract and test Format_MP, add defaults

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -301,8 +301,8 @@ bool isNonMainNet()
 // TODO: move into mastercore_parse_string.h/.cpp
 std::string FormatMP(unsigned int property, int64_t n, bool fSign)
 {
-  if (isPropertyDivisible(property)) return FormatDivisibleMP(n, fSign);
-  else return FormatIndivisibleMP(n);
+  if (isPropertyDivisible(property)) return FormatDivisibleAmount(n, fSign);
+  else return FormatIndivisibleAmount(n);
 }
 
 string const CMPSPInfo::watermarkKey("watermark");

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -77,6 +77,7 @@ using namespace mastercore;
 #include "mastercore_tx.h"
 #include "mastercore_sp.h"
 #include "mastercore_errors.h"
+#include "mastercore_parse_string.h"
 
 // part of 'breakout' feature
 static const int nBlockTop = 0;
@@ -297,31 +298,7 @@ bool isNonMainNet()
   return (TestNet() || RegTest());
 }
 
-// mostly taken from Bitcoin's FormatMoney()
-string FormatDivisibleMP(int64_t n, bool fSign)
-{
-// Note: not using straight sprintf here because we do NOT want
-// localized number formatting.
-int64_t n_abs = (n > 0 ? n : -n);
-int64_t quotient = n_abs/COIN;
-int64_t remainder = n_abs%COIN;
-string str = strprintf("%d.%08d", quotient, remainder);
-
-  if (!fSign) return str;
-
-  if (n < 0)
-      str.insert((unsigned int)0, 1, '-');
-  else
-      str.insert((unsigned int)0, 1, '+');
-  return str;
-}
-
-std::string mastercore::FormatIndivisibleMP(int64_t n)
-{
-  string str = strprintf("%ld", n);
-  return str;
-}
-
+// TODO: move into mastercore_parse_string.h/.cpp
 std::string FormatMP(unsigned int property, int64_t n, bool fSign)
 {
   if (isPropertyDivisible(property)) return FormatDivisibleMP(n, fSign);

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -6,6 +6,8 @@
 #ifndef _MASTERCOIN
 #define _MASTERCOIN 1
 
+#include "mastercore_parse_string.h"
+
 #include "netbase.h"
 #include "protocol.h"
 
@@ -132,8 +134,7 @@ enum FILETYPES {
 #define MASTERCOIN_CURRENCY_TMSC  2
 
 // forward declarations
-std::string FormatDivisibleMP(int64_t n, bool fSign = false);
-std::string FormatMP(unsigned int, int64_t n, bool fSign = false);
+std::string FormatMP(unsigned int, int64_t n, bool fSign = false); // TODO: move into mastercore_parse_string.h/.cpp
 uint256 send_MP(const string &FromAddress, const string &ToAddress, const string &RedeemAddress, unsigned int CurrencyID, uint64_t Amount);
 int64_t feeCheck(const string &address);
 
@@ -240,7 +241,10 @@ public:
     if (bDivisible)
     {
       printf("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
-       FormatDivisibleMP(money, true).c_str(), FormatDivisibleMP(so_r, true).c_str(), FormatDivisibleMP(a_r, true).c_str(), FormatDivisibleMP(pending, true).c_str());
+        mastercore::FormatDivisibleMP(money, true).c_str(),
+        mastercore::FormatDivisibleMP(so_r, true).c_str(),
+        mastercore::FormatDivisibleMP(a_r, true).c_str(),
+        mastercore::FormatDivisibleMP(pending, true).c_str());
     }
     else
     {
@@ -389,7 +393,6 @@ string getPropertyName(unsigned int propertyId);
 bool isCrowdsaleActive(unsigned int propertyId);
 bool isCrowdsalePurchase(uint256 txid, string address, int64_t *propertyId = NULL, int64_t *userTokens = NULL, int64_t *issuerTokens = NULL);
 bool isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound);
-std::string FormatIndivisibleMP(int64_t n);
 
 int ClassB_send(const string &senderAddress, const string &receiverAddress, const string &redemptionAddress, const vector<unsigned char> &data, uint256 & txid, int64_t additional = 0);
 

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -241,10 +241,10 @@ public:
     if (bDivisible)
     {
       printf("%22s [SO_RESERVE= %22s , ACCEPT_RESERVE= %22s ] %22s\n",
-        mastercore::FormatDivisibleMP(money, true).c_str(),
-        mastercore::FormatDivisibleMP(so_r, true).c_str(),
-        mastercore::FormatDivisibleMP(a_r, true).c_str(),
-        mastercore::FormatDivisibleMP(pending, true).c_str());
+        mastercore::FormatDivisibleAmount(money, true).c_str(),
+        mastercore::FormatDivisibleAmount(so_r, true).c_str(),
+        mastercore::FormatDivisibleAmount(a_r, true).c_str(),
+        mastercore::FormatDivisibleAmount(pending, true).c_str());
     }
     else
     {

--- a/src/mastercore_parse_string.cpp
+++ b/src/mastercore_parse_string.cpp
@@ -1,5 +1,7 @@
 #include "mastercore_parse_string.h"
 
+#include "util.h"
+
 #include <stdint.h>
 #include <algorithm>
 #include <string>
@@ -8,6 +10,30 @@
 
 namespace mastercore
 {
+std::string FormatDivisibleMP(int64_t n, bool fSign)
+{
+    // Note: not using straight sprintf here because we do NOT want
+    // localized number formatting.
+    int64_t n_abs = (n > 0 ? n : -n);
+    int64_t quotient = n_abs/COIN;
+    int64_t remainder = n_abs%COIN;
+    std::string str = strprintf("%d.%08d", quotient, remainder);
+
+    if (!fSign) return str;
+
+    if (n < 0)
+        str.insert((unsigned int)0, 1, '-');
+    else
+        str.insert((unsigned int)0, 1, '+');
+    return str;
+}
+
+std::string FormatIndivisibleMP(int64_t n)
+{
+    std::string str = strprintf("%ld", n);
+    return str;
+}
+
 int64_t StrToInt64(const std::string& str, bool divisible)
 {    
     // copy original, so it remains unchanged

--- a/src/mastercore_parse_string.cpp
+++ b/src/mastercore_parse_string.cpp
@@ -10,7 +10,7 @@
 
 namespace mastercore
 {
-std::string FormatDivisibleMP(int64_t n, bool fSign)
+std::string FormatDivisibleAmount(int64_t n, bool fSign)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
@@ -28,7 +28,7 @@ std::string FormatDivisibleMP(int64_t n, bool fSign)
     return str;
 }
 
-std::string FormatIndivisibleMP(int64_t n)
+std::string FormatIndivisibleAmount(int64_t n)
 {
     std::string str = strprintf("%ld", n);
     return str;

--- a/src/mastercore_parse_string.cpp
+++ b/src/mastercore_parse_string.cpp
@@ -10,28 +10,52 @@
 
 namespace mastercore
 {
-std::string FormatDivisibleAmount(int64_t n, bool fSign)
+std::string FormatDivisibleAmount(int64_t n)
+{
+    // Prepend sign only for negative numbers
+    bool is_negative = (n < 0);
+
+    return FormatDivisibleAmount(n, is_negative);
+}
+
+std::string FormatDivisibleAmount(int64_t n, bool sign)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
     int64_t n_abs = (n > 0 ? n : -n);
-    int64_t quotient = n_abs/COIN;
-    int64_t remainder = n_abs%COIN;
-    std::string str = strprintf("%d.%08d", quotient, remainder);
+    int64_t quotient = n_abs / COIN;
+    int64_t remainder = n_abs % COIN;
+    std::string str = tfm::format("%ld.%08d", quotient, remainder);
 
-    if (!fSign) return str;
+    if (!sign)
+        return str;
 
     if (n < 0)
-        str.insert((unsigned int)0, 1, '-');
+        str.insert((unsigned int) 0, 1, '-');
     else
-        str.insert((unsigned int)0, 1, '+');
+        str.insert((unsigned int) 0, 1, '+');
+
     return str;
 }
 
 std::string FormatIndivisibleAmount(int64_t n)
 {
-    std::string str = strprintf("%ld", n);
-    return str;
+    return tfm::format("%ld", n);
+}
+
+std::string FormatTokenAmount(int64_t n)
+{
+    // Default token amounts are formatted as indivisible
+    // token which aligns well with an integer input
+    return FormatIndivisibleAmount(n);
+}
+
+std::string FormatTokenAmount(int64_t n, bool divisible)
+{
+    if (divisible)
+        return FormatDivisibleAmount(n);
+
+    return FormatIndivisibleAmount(n);
 }
 
 int64_t StrToInt64(const std::string& str, bool divisible)

--- a/src/mastercore_parse_string.h
+++ b/src/mastercore_parse_string.h
@@ -6,6 +6,10 @@
 
 namespace mastercore
 {
+// TODO: add FormatMP() -- currently depends on isPropertyDivisible()
+std::string FormatDivisibleMP(int64_t n, bool fSign = false);
+std::string FormatIndivisibleMP(int64_t n);
+
 // Converts strings to 64 bit wide interger.
 // Divisible and indivisible amounts are accepted.
 // 1 indivisible unit equals 0.00000001 divisible units.
@@ -17,4 +21,4 @@ namespace mastercore
 int64_t StrToInt64(const std::string& str, bool divisible);
 }
 
-#endif // _MASTERCOIN_PARSE_STRRING
+#endif // _MASTERCOIN_PARSE_STRING

--- a/src/mastercore_parse_string.h
+++ b/src/mastercore_parse_string.h
@@ -7,8 +7,22 @@
 namespace mastercore
 {
 // TODO: add FormatMP() -- currently depends on isPropertyDivisible()
-std::string FormatDivisibleAmount(int64_t n, bool fSign = false);
+
+// Formats a value as divisible token amount with 8 digits.
+// Per default a minus sign is prepended, if n is negative.
+// A positive or negative sign can be enforced.
+std::string FormatDivisibleAmount(int64_t n);
+std::string FormatDivisibleAmount(int64_t n, bool sign);
+
+// Formats a value as indivisible token amount with leading
+// minus sign, if n is negative.
 std::string FormatIndivisibleAmount(int64_t n);
+
+// Formats a value as token amount and prepends a minus sign,
+// if the value is negative. Divisible amounts have 8 digits.
+// Per default n is formatted as indivisible amount.
+std::string FormatTokenAmount(int64_t n);
+std::string FormatTokenAmount(int64_t n, bool divisible);
 
 // Converts strings to 64 bit wide interger.
 // Divisible and indivisible amounts are accepted.

--- a/src/mastercore_parse_string.h
+++ b/src/mastercore_parse_string.h
@@ -7,8 +7,8 @@
 namespace mastercore
 {
 // TODO: add FormatMP() -- currently depends on isPropertyDivisible()
-std::string FormatDivisibleMP(int64_t n, bool fSign = false);
-std::string FormatIndivisibleMP(int64_t n);
+std::string FormatDivisibleAmount(int64_t n, bool fSign = false);
+std::string FormatIndivisibleAmount(int64_t n);
 
 // Converts strings to 64 bit wide interger.
 // Divisible and indivisible amounts are accepted.

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -82,7 +82,7 @@ int extra2 = 0, extra3 = 0;
           total += (my_it->second).print(extra2, bDivisible);
         }
 
-        printf("total for property %d  = %X is %s\n", extra2, extra2, FormatDivisibleMP(total).c_str());
+        printf("total for property %d  = %X is %s\n", extra2, extra2, FormatDivisibleAmount(total).c_str());
       }
       break;
 
@@ -171,13 +171,13 @@ Value getbalance_MP(const Array& params, bool fHelp)
 
     if (divisible)
     {
-        balObj.push_back(Pair("balance", FormatDivisibleMP(tmpBalAvailable)));
-        balObj.push_back(Pair("reserved", FormatDivisibleMP(tmpBalReservedSell+tmpBalReservedAccept)));
+        balObj.push_back(Pair("balance", FormatDivisibleAmount(tmpBalAvailable)));
+        balObj.push_back(Pair("reserved", FormatDivisibleAmount(tmpBalReservedSell+tmpBalReservedAccept)));
     }
     else
     {
-        balObj.push_back(Pair("balance", FormatIndivisibleMP(tmpBalAvailable)));
-        balObj.push_back(Pair("reserved", FormatIndivisibleMP(tmpBalReservedSell+tmpBalReservedAccept)));
+        balObj.push_back(Pair("balance", FormatIndivisibleAmount(tmpBalAvailable)));
+        balObj.push_back(Pair("reserved", FormatIndivisibleAmount(tmpBalReservedSell+tmpBalReservedAccept)));
     }
 
     return balObj;
@@ -401,13 +401,13 @@ Value getallbalancesforid_MP(const Array& params, bool fHelp)
         addressbal.push_back(Pair("address", address));
         if(divisible)
         {
-        addressbal.push_back(Pair("balance", FormatDivisibleMP(tmpBalAvailable)));
-        addressbal.push_back(Pair("reserved", FormatDivisibleMP(tmpBalReservedSell+tmpBalReservedAccept)));
+        addressbal.push_back(Pair("balance", FormatDivisibleAmount(tmpBalAvailable)));
+        addressbal.push_back(Pair("reserved", FormatDivisibleAmount(tmpBalReservedSell+tmpBalReservedAccept)));
         }
         else
         {
-        addressbal.push_back(Pair("balance", FormatIndivisibleMP(tmpBalAvailable)));
-        addressbal.push_back(Pair("reserved", FormatIndivisibleMP(tmpBalReservedSell+tmpBalReservedAccept)));
+        addressbal.push_back(Pair("balance", FormatIndivisibleAmount(tmpBalAvailable)));
+        addressbal.push_back(Pair("reserved", FormatIndivisibleAmount(tmpBalReservedSell+tmpBalReservedAccept)));
         }
         response.push_back(addressbal);
     }
@@ -469,13 +469,13 @@ Value getallbalancesforaddress_MP(const Array& params, bool fHelp)
 
             if (divisible)
             {
-                    propertyBal.push_back(Pair("balance", FormatDivisibleMP(tmpBalAvailable)));
-                    propertyBal.push_back(Pair("reserved", FormatDivisibleMP(tmpBalReservedSell+tmpBalReservedAccept)));
+                    propertyBal.push_back(Pair("balance", FormatDivisibleAmount(tmpBalAvailable)));
+                    propertyBal.push_back(Pair("reserved", FormatDivisibleAmount(tmpBalReservedSell+tmpBalReservedAccept)));
             }
             else
             {
-                    propertyBal.push_back(Pair("balance", FormatIndivisibleMP(tmpBalAvailable)));
-                    propertyBal.push_back(Pair("reserved", FormatIndivisibleMP(tmpBalReservedSell+tmpBalReservedAccept)));
+                    propertyBal.push_back(Pair("balance", FormatIndivisibleAmount(tmpBalAvailable)));
+                    propertyBal.push_back(Pair("reserved", FormatIndivisibleAmount(tmpBalReservedSell+tmpBalReservedAccept)));
             }
 
             response.push_back(propertyBal);
@@ -546,11 +546,11 @@ Value getproperty_MP(const Array& params, bool fHelp)
         response.push_back(Pair("fixedissuance", fixedIssuance));
         if (divisible)
         {
-            response.push_back(Pair("totaltokens", FormatDivisibleMP(totalTokens)));
+            response.push_back(Pair("totaltokens", FormatDivisibleAmount(totalTokens)));
         }
         else
         {
-            response.push_back(Pair("totaltokens", FormatIndivisibleMP(totalTokens)));
+            response.push_back(Pair("totaltokens", FormatIndivisibleAmount(totalTokens)));
         }
 
 return response;
@@ -766,27 +766,27 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
         participanttx.push_back(Pair("txid", txid)); //.GetHex()).c_str();
         if (divisibleDesired)
         {
-             participanttx.push_back(Pair("amountsent", FormatDivisibleMP(amountSent)));
+             participanttx.push_back(Pair("amountsent", FormatDivisibleAmount(amountSent)));
         }
         else
         {
-             participanttx.push_back(Pair("amountsent", FormatIndivisibleMP(amountSent)));
+             participanttx.push_back(Pair("amountsent", FormatIndivisibleAmount(amountSent)));
         }
         if (divisible)
         {
-             participanttx.push_back(Pair("participanttokens", FormatDivisibleMP(userTokens)));
+             participanttx.push_back(Pair("participanttokens", FormatDivisibleAmount(userTokens)));
         }
         else
         {
-             participanttx.push_back(Pair("participanttokens", FormatIndivisibleMP(userTokens)));
+             participanttx.push_back(Pair("participanttokens", FormatIndivisibleAmount(userTokens)));
         }
         if (divisible)
         {
-             participanttx.push_back(Pair("issuertokens", FormatDivisibleMP(issuerTokens)));
+             participanttx.push_back(Pair("issuertokens", FormatDivisibleAmount(issuerTokens)));
         }
         else
         {
-             participanttx.push_back(Pair("issuertokens", FormatIndivisibleMP(issuerTokens)));
+             participanttx.push_back(Pair("issuertokens", FormatIndivisibleAmount(issuerTokens)));
         }
         participanttxs.push_back(participanttx);
     }
@@ -797,11 +797,11 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
     response.push_back(Pair("propertyiddesired", propertyIdDesired));
     if (divisible)
     {
-        response.push_back(Pair("tokensperunit", FormatDivisibleMP(tokensPerUnit)));
+        response.push_back(Pair("tokensperunit", FormatDivisibleAmount(tokensPerUnit)));
     }
     else
     {
-        response.push_back(Pair("tokensperunit", FormatIndivisibleMP(tokensPerUnit)));
+        response.push_back(Pair("tokensperunit", FormatIndivisibleAmount(tokensPerUnit)));
     }
     response.push_back(Pair("earlybonus", earlyBonus));
     response.push_back(Pair("percenttoissuer", percentToIssuer));
@@ -810,21 +810,21 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
 
     if (divisibleDesired)
     {
-        response.push_back(Pair("amountraised", FormatDivisibleMP(amountRaised)));
+        response.push_back(Pair("amountraised", FormatDivisibleAmount(amountRaised)));
     }
     else
     {
-        response.push_back(Pair("amountraised", FormatIndivisibleMP(amountRaised)));
+        response.push_back(Pair("amountraised", FormatIndivisibleAmount(amountRaised)));
     }
     if (divisible)
     {
-        response.push_back(Pair("tokensissued", FormatDivisibleMP(tokensIssued)));
-        response.push_back(Pair("addedissuertokens", FormatDivisibleMP(missedTokens)));
+        response.push_back(Pair("tokensissued", FormatDivisibleAmount(tokensIssued)));
+        response.push_back(Pair("addedissuertokens", FormatDivisibleAmount(missedTokens)));
     }
     else
     {
-        response.push_back(Pair("tokensissued", FormatIndivisibleMP(tokensIssued)));
-        response.push_back(Pair("addedissuertokens", FormatIndivisibleMP(missedTokens)));
+        response.push_back(Pair("tokensissued", FormatIndivisibleAmount(tokensIssued)));
+        response.push_back(Pair("addedissuertokens", FormatIndivisibleAmount(missedTokens)));
     }
     if (!active) response.push_back(Pair("closedearly", closeEarly));
     if (!active) response.push_back(Pair("maxtokens", maxTokens));
@@ -902,11 +902,11 @@ Value getactivecrowdsales_MP(const Array& params, bool fHelp)
               responseObj.push_back(Pair("propertyiddesired", propertyIdDesired));
               if (divisible)
               {
-                  responseObj.push_back(Pair("tokensperunit", FormatDivisibleMP(tokensPerUnit)));
+                  responseObj.push_back(Pair("tokensperunit", FormatDivisibleAmount(tokensPerUnit)));
               }
               else
               {
-                  responseObj.push_back(Pair("tokensperunit", FormatIndivisibleMP(tokensPerUnit)));
+                  responseObj.push_back(Pair("tokensperunit", FormatIndivisibleAmount(tokensPerUnit)));
               }
               responseObj.push_back(Pair("earlybonus", earlyBonus));
               responseObj.push_back(Pair("percenttoissuer", percentToIssuer));
@@ -989,9 +989,9 @@ Value getgrants_MP(const Array& params, bool fHelp)
           Object granttx;
           granttx.push_back(Pair("txid", txid));
           if (sp.isDivisible()) {
-            granttx.push_back(Pair("grant", FormatDivisibleMP(grantedTokens)));
+            granttx.push_back(Pair("grant", FormatDivisibleAmount(grantedTokens)));
           } else {
-            granttx.push_back(Pair("grant", FormatIndivisibleMP(grantedTokens)));
+            granttx.push_back(Pair("grant", FormatIndivisibleAmount(grantedTokens)));
           }
           issuancetxs.push_back(granttx);
         }
@@ -1000,9 +1000,9 @@ Value getgrants_MP(const Array& params, bool fHelp)
           Object revoketx;
           revoketx.push_back(Pair("txid", txid));
           if (sp.isDivisible()) {
-            revoketx.push_back(Pair("revoke", FormatDivisibleMP(revokedTokens)));
+            revoketx.push_back(Pair("revoke", FormatDivisibleAmount(revokedTokens)));
           } else {
-            revoketx.push_back(Pair("revoke", FormatIndivisibleMP(revokedTokens)));
+            revoketx.push_back(Pair("revoke", FormatIndivisibleAmount(revokedTokens)));
           }
           issuancetxs.push_back(revoketx);
         }
@@ -1012,9 +1012,9 @@ Value getgrants_MP(const Array& params, bool fHelp)
     response.push_back(Pair("issuer", issuer));
     response.push_back(Pair("creationtxid", creationHash.GetHex()));
     if (sp.isDivisible()) {
-      response.push_back(Pair("totaltokens", FormatDivisibleMP(totalTokens)));
+      response.push_back(Pair("totaltokens", FormatDivisibleAmount(totalTokens)));
     } else {
-      response.push_back(Pair("totaltokens", FormatIndivisibleMP(totalTokens)));
+      response.push_back(Pair("totaltokens", FormatIndivisibleAmount(totalTokens)));
     }
     response.push_back(Pair("issuances", issuancetxs));
     return response;
@@ -1047,8 +1047,8 @@ void add_mdex_fields(Object *metadex_obj, CMPMetaDEx obj, bool c_own_div, bool c
   //metadex_obj->push_back(Pair("unit_price", strprintf("%lu.%.8s",  price[0],  boost::lexical_cast<std::string>(price[1]) ).c_str() ) );
   //metadex_obj->push_back(Pair("inverse_unit_price", strprintf("%lu.%.8s", invprice[0], boost::lexical_cast<std::string>(invprice[1]) ).c_str() ) );
   //active?
-  metadex_obj->push_back(Pair("amount_original", FormatDivisibleMP(obj.getAmtOrig())));
-  metadex_obj->push_back(Pair("amount_desired", FormatDivisibleMP(obj.getAmtDes())));
+  metadex_obj->push_back(Pair("amount_original", FormatDivisibleAmount(obj.getAmtOrig())));
+  metadex_obj->push_back(Pair("amount_desired", FormatDivisibleAmount(obj.getAmtDes())));
   metadex_obj->push_back(Pair("action", (uint64_t) obj.getAction()));
   metadex_obj->push_back(Pair("block", obj.getBlock()));
   metadex_obj->push_back(Pair("blockTime", obj.getBlockTime()));
@@ -1407,14 +1407,14 @@ Value getactivedexsells_MP(const Array& params, bool fHelp)
           responseObj.push_back(Pair("txid", txid));
           responseObj.push_back(Pair("propertyid", propertyId));
           responseObj.push_back(Pair("seller", seller));
-          responseObj.push_back(Pair("amountavailable", FormatDivisibleMP(amountAvailable)));
-          responseObj.push_back(Pair("bitcoindesired", FormatDivisibleMP(bitcoinDesired)));
-          responseObj.push_back(Pair("unitprice", FormatDivisibleMP(unitPrice)));
+          responseObj.push_back(Pair("amountavailable", FormatDivisibleAmount(amountAvailable)));
+          responseObj.push_back(Pair("bitcoindesired", FormatDivisibleAmount(bitcoinDesired)));
+          responseObj.push_back(Pair("unitprice", FormatDivisibleAmount(unitPrice)));
           responseObj.push_back(Pair("timelimit", timeLimit));
-          responseObj.push_back(Pair("minimumfee", FormatDivisibleMP(minFee)));
+          responseObj.push_back(Pair("minimumfee", FormatDivisibleAmount(minFee)));
 
           // display info about accepts related to sell
-          responseObj.push_back(Pair("amountaccepted", FormatDivisibleMP(amountAccepted)));
+          responseObj.push_back(Pair("amountaccepted", FormatDivisibleAmount(amountAccepted)));
           Array acceptsMatched;
           for(AcceptMap::iterator ait = my_accepts.begin(); ait != my_accepts.end(); ++ait)
           {
@@ -1432,7 +1432,7 @@ Value getactivedexsells_MP(const Array& params, bool fHelp)
                   uint64_t acceptAmount = accept.getAcceptAmountRemaining();
                   matchedAccept.push_back(Pair("buyer", buyer));
                   matchedAccept.push_back(Pair("block", acceptBlock));
-                  matchedAccept.push_back(Pair("amount", FormatDivisibleMP(acceptAmount)));
+                  matchedAccept.push_back(Pair("amount", FormatDivisibleAmount(acceptAmount)));
                   acceptsMatched.push_back(matchedAccept);
               }
           }
@@ -1605,11 +1605,11 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
                         if (!filterAddress.empty()) if ((buyer != filterAddress) && (seller != filterAddress)) return -1; // return negative rc if filtering & no match
                         uint64_t amountPaid = wtx.vout[vout].nValue;
                         purchaseObj.push_back(Pair("vout", vout));
-                        purchaseObj.push_back(Pair("amountpaid", FormatDivisibleMP(amountPaid)));
+                        purchaseObj.push_back(Pair("amountpaid", FormatDivisibleAmount(amountPaid)));
                         purchaseObj.push_back(Pair("ismine", bIsMine));
                         purchaseObj.push_back(Pair("referenceaddress", seller));
                         purchaseObj.push_back(Pair("propertyid", propertyId));
-                        purchaseObj.push_back(Pair("amountbought", FormatDivisibleMP(nValue)));
+                        purchaseObj.push_back(Pair("amountbought", FormatDivisibleAmount(nValue)));
                         purchaseObj.push_back(Pair("valid", true)); //only valid purchases are stored, anything else is regular BTC tx
                         purchases.push_back(purchaseObj);
                     }
@@ -1824,11 +1824,11 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
         txobj->push_back(Pair("divisible", divisible));
         if (divisible)
         {
-            txobj->push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
+            txobj->push_back(Pair("amount", FormatDivisibleAmount(amount))); //divisible, format w/ bitcoins VFA func
         }
         else
         {
-            txobj->push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
+            txobj->push_back(Pair("amount", FormatIndivisibleAmount(amount))); //indivisible, push raw 64
         }
         if (crowdPurchase)
         {
@@ -1837,13 +1837,13 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
             txobj->push_back(Pair("purchasedpropertydivisible", crowdDivisible));
             if (crowdDivisible)
             {
-                txobj->push_back(Pair("purchasedtokens", FormatDivisibleMP(crowdTokens))); //divisible, format w/ bitcoins VFA func
-                txobj->push_back(Pair("issuertokens", FormatDivisibleMP(issuerTokens)));
+                txobj->push_back(Pair("purchasedtokens", FormatDivisibleAmount(crowdTokens))); //divisible, format w/ bitcoins VFA func
+                txobj->push_back(Pair("issuertokens", FormatDivisibleAmount(issuerTokens)));
             }
             else
             {
-                txobj->push_back(Pair("purchasedtokens", FormatIndivisibleMP(crowdTokens))); //indivisible, push raw 64
-                txobj->push_back(Pair("issuertokens", FormatIndivisibleMP(issuerTokens)));
+                txobj->push_back(Pair("purchasedtokens", FormatIndivisibleAmount(crowdTokens))); //indivisible, push raw 64
+                txobj->push_back(Pair("issuertokens", FormatIndivisibleAmount(issuerTokens)));
             }
         }
         if (MSC_TYPE_TRADE_OFFER == MPTxTypeInt)
@@ -1864,8 +1864,8 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
             //txobj->push_back(Pair("unit_price", mdex_unitPrice ) );
             //txobj->push_back(Pair("inverse_unit_price", mdex_invUnitPrice ) );
             //active?
-            txobj->push_back(Pair("amount_original", FormatDivisibleMP(mdex_amt_orig_sale)));
-            txobj->push_back(Pair("amount_desired", FormatDivisibleMP(mdex_amt_des)));
+            txobj->push_back(Pair("amount_original", FormatDivisibleAmount(mdex_amt_orig_sale)));
+            txobj->push_back(Pair("amount_desired", FormatDivisibleAmount(mdex_amt_des)));
             txobj->push_back(Pair("action", (uint64_t) mdex_action));
         }
         txobj->push_back(Pair("valid", valid));

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -148,7 +148,7 @@ void SendMPDialog::updateFrom()
     }
     else
     {
-       string feeWarning = "Only " + FormatDivisibleMP(inputTotal) + " BTC are available at the sending address for fees, you can attempt to send the transaction anyway but this *may* not be sufficient.";
+       string feeWarning = "Only " + FormatDivisibleAmount(inputTotal) + " BTC are available at the sending address for fees, you can attempt to send the transaction anyway but this *may* not be sufficient.";
        ui->feeWarningLabel->setText(QString::fromStdString(feeWarning));
        ui->feeWarningLabel->setVisible(true);
     }
@@ -218,13 +218,13 @@ void SendMPDialog::updateBalances()
     if (propertyId>2) tokenLabel = " SPT";
     if (isPropertyDivisible(propertyId))
     {
-        balanceLabel = QString::fromStdString("Address Balance (Available): " + FormatDivisibleMP(balanceAvailable) + tokenLabel);
-        globalLabel = QString::fromStdString("Wallet Balance (Available): " + FormatDivisibleMP(globalAvailable) + tokenLabel);
+        balanceLabel = QString::fromStdString("Address Balance (Available): " + FormatDivisibleAmount(balanceAvailable) + tokenLabel);
+        globalLabel = QString::fromStdString("Wallet Balance (Available): " + FormatDivisibleAmount(globalAvailable) + tokenLabel);
     }
     else
     {
-        balanceLabel = QString::fromStdString("Address Balance (Available): " + FormatIndivisibleMP(balanceAvailable) + tokenLabel);
-        globalLabel = QString::fromStdString("Wallet Balance (Available): " + FormatIndivisibleMP(globalAvailable) + tokenLabel);
+        balanceLabel = QString::fromStdString("Address Balance (Available): " + FormatIndivisibleAmount(balanceAvailable) + tokenLabel);
+        globalLabel = QString::fromStdString("Wallet Balance (Available): " + FormatIndivisibleAmount(globalAvailable) + tokenLabel);
     }
     ui->addressBalanceLabel->setText(balanceLabel);
     ui->globalBalanceLabel->setText(globalLabel);
@@ -328,7 +328,7 @@ void SendMPDialog::sendMPTransaction()
     string spNum = static_cast<ostringstream*>( &(ostringstream() << propertyId) )->str();
     propDetails += " (#" + spNum + ")";
     strMsgText += "From: " + fromAddress.ToString() + "\nTo: " + refAddress.ToString() + "\nProperty: " + propDetails + "\nAmount that will be sent: ";
-    if (divisible) { strMsgText += FormatDivisibleMP(sendAmount); } else { strMsgText += FormatIndivisibleMP(sendAmount); }
+    if (divisible) { strMsgText += FormatDivisibleAmount(sendAmount); } else { strMsgText += FormatIndivisibleAmount(sendAmount); }
     strMsgText += "\n\nAre you sure you wish to send this transaction?";
     QString msgText = QString::fromStdString(strMsgText);
     QMessageBox::StandardButton responseClick;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -898,13 +898,13 @@ int MatrixModel::fillin(unsigned int propertyId)
                 bool divisible = isPropertyDivisible(propertyId);
                 if (divisible)
                 {
-                    ql_avl.append(QString::fromStdString(FormatDivisibleMP(available)));
-                    ql_res.append(QString::fromStdString(FormatDivisibleMP(reserved)));
+                    ql_avl.append(QString::fromStdString(FormatDivisibleAmount(available)));
+                    ql_res.append(QString::fromStdString(FormatDivisibleAmount(reserved)));
                 }
                 else
                 {
-                    ql_avl.append(QString::fromStdString(FormatIndivisibleMP(available)));
-                    ql_res.append(QString::fromStdString(FormatIndivisibleMP(reserved)));
+                    ql_avl.append(QString::fromStdString(FormatIndivisibleAmount(available)));
+                    ql_res.append(QString::fromStdString(FormatIndivisibleAmount(reserved)));
                 }
                 ++count;
             }
@@ -923,13 +923,13 @@ int MatrixModel::fillin(unsigned int propertyId)
                 bool divisible = isPropertyDivisible(propertyId+2147483647);
                 if (divisible)
                 {
-                    ql_avl.append(QString::fromStdString(FormatDivisibleMP(available)));
-                    ql_res.append(QString::fromStdString(FormatDivisibleMP(reserved)));
+                    ql_avl.append(QString::fromStdString(FormatDivisibleAmount(available)));
+                    ql_res.append(QString::fromStdString(FormatDivisibleAmount(reserved)));
                 }
                 else
                 {
-                    ql_avl.append(QString::fromStdString(FormatIndivisibleMP(available)));
-                    ql_res.append(QString::fromStdString(FormatIndivisibleMP(reserved)));
+                    ql_avl.append(QString::fromStdString(FormatIndivisibleAmount(available)));
+                    ql_res.append(QString::fromStdString(FormatIndivisibleAmount(reserved)));
                 }
                 ++count;
              }
@@ -961,13 +961,13 @@ int MatrixModel::fillin(unsigned int propertyId)
             ql_addr.append((my_it->first).c_str());
             if (divisible)
             {
-                ql_avl.append(QString::fromStdString(FormatDivisibleMP(available)));
-                ql_res.append(QString::fromStdString(FormatDivisibleMP(reserved)));
+                ql_avl.append(QString::fromStdString(FormatDivisibleAmount(available)));
+                ql_res.append(QString::fromStdString(FormatDivisibleAmount(reserved)));
             }
             else
             {
-                ql_avl.append(QString::fromStdString(FormatIndivisibleMP(available)));
-                ql_res.append(QString::fromStdString(FormatIndivisibleMP(reserved)));
+                ql_avl.append(QString::fromStdString(FormatIndivisibleAmount(available)));
+                ql_res.append(QString::fromStdString(FormatIndivisibleAmount(reserved)));
             }
             ++count;
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -61,6 +61,7 @@ using namespace leveldb;
 #include "mastercore_dex.h"
 #include "mastercore_tx.h"
 #include "mastercore_sp.h"
+#include "mastercore_parse_string.h"
 
 #include <QColor>
 #include <QDateTime>

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -48,6 +48,7 @@ test_bitcoin_SOURCES = \
   key_tests.cpp \
   main_tests.cpp \
   mastercore_strtoint64_tests.cpp \
+  mastercore_format_tests.cpp \
   miner_tests.cpp \
   mruset_tests.cpp \
   multisig_tests.cpp \

--- a/src/test/mastercore_format_tests.cpp
+++ b/src/test/mastercore_format_tests.cpp
@@ -1,0 +1,188 @@
+#include "mastercore_parse_string.h"
+
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(mastercore_format_tests)
+
+BOOST_AUTO_TEST_CASE(mastercore_format_indivisible)
+{
+    // positive numbers
+    BOOST_CHECK("0" == FormatIndivisibleAmount(0));
+    BOOST_CHECK("1" == FormatIndivisibleAmount(1));
+    BOOST_CHECK("10" == FormatIndivisibleAmount(10));
+    BOOST_CHECK("100" == FormatIndivisibleAmount(100));
+    BOOST_CHECK("1000" == FormatIndivisibleAmount(1000));
+    BOOST_CHECK("10000" == FormatIndivisibleAmount(10000));
+    BOOST_CHECK("100000" == FormatIndivisibleAmount(100000));
+    BOOST_CHECK("1000000" == FormatIndivisibleAmount(1000000));
+    BOOST_CHECK("10000000" == FormatIndivisibleAmount(10000000));
+    BOOST_CHECK("100000000" == FormatIndivisibleAmount(100000000));
+    BOOST_CHECK("1000000000" == FormatIndivisibleAmount(1000000000));
+    BOOST_CHECK("10000000000" == FormatIndivisibleAmount(10000000000));
+    BOOST_CHECK("100000000000" == FormatIndivisibleAmount(100000000000));
+    BOOST_CHECK("1000000000000" == FormatIndivisibleAmount(1000000000000));
+    BOOST_CHECK("10000000000000" == FormatIndivisibleAmount(10000000000000));
+    BOOST_CHECK("100000000000000" == FormatIndivisibleAmount(100000000000000));
+    BOOST_CHECK("1000000000000000" == FormatIndivisibleAmount(1000000000000000));
+    BOOST_CHECK("10000000000000000" == FormatIndivisibleAmount(10000000000000000));
+    BOOST_CHECK("100000000000000000" == FormatIndivisibleAmount(100000000000000000));
+    BOOST_CHECK("1000000000000000000" == FormatIndivisibleAmount(1000000000000000000));
+
+    // negative numbers
+    BOOST_CHECK("-1" == FormatIndivisibleAmount(-1));
+    BOOST_CHECK("-10" == FormatIndivisibleAmount(-10));
+    BOOST_CHECK("-100" == FormatIndivisibleAmount(-100));
+    BOOST_CHECK("-1000" == FormatIndivisibleAmount(-1000));
+    BOOST_CHECK("-10000" == FormatIndivisibleAmount(-10000));
+    BOOST_CHECK("-100000" == FormatIndivisibleAmount(-100000));
+    BOOST_CHECK("-1000000" == FormatIndivisibleAmount(-1000000));
+    BOOST_CHECK("-10000000" == FormatIndivisibleAmount(-10000000));
+    BOOST_CHECK("-100000000" == FormatIndivisibleAmount(-100000000));
+    BOOST_CHECK("-1000000000" == FormatIndivisibleAmount(-1000000000));
+    BOOST_CHECK("-10000000000" == FormatIndivisibleAmount(-10000000000));
+    BOOST_CHECK("-100000000000" == FormatIndivisibleAmount(-100000000000));
+    BOOST_CHECK("-1000000000000" == FormatIndivisibleAmount(-1000000000000));
+    BOOST_CHECK("-10000000000000" == FormatIndivisibleAmount(-10000000000000));
+    BOOST_CHECK("-100000000000000" == FormatIndivisibleAmount(-100000000000000));
+    BOOST_CHECK("-1000000000000000" == FormatIndivisibleAmount(-1000000000000000));
+    BOOST_CHECK("-10000000000000000" == FormatIndivisibleAmount(-10000000000000000));
+    BOOST_CHECK("-100000000000000000" == FormatIndivisibleAmount(-100000000000000000));
+    BOOST_CHECK("-1000000000000000000" == FormatIndivisibleAmount(-1000000000000000000));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_signed)
+{
+    // positive numbers
+    BOOST_CHECK("+0.00000000" == FormatDivisibleAmount(0, true));
+    BOOST_CHECK("+0.00000001" == FormatDivisibleAmount(1, true));
+    BOOST_CHECK("+0.00000010" == FormatDivisibleAmount(10, true));
+    BOOST_CHECK("+0.00000100" == FormatDivisibleAmount(100, true));
+    BOOST_CHECK("+0.00001000" == FormatDivisibleAmount(1000, true));
+    BOOST_CHECK("+0.00010000" == FormatDivisibleAmount(10000, true));
+    BOOST_CHECK("+0.00100000" == FormatDivisibleAmount(100000, true));
+    BOOST_CHECK("+0.01000000" == FormatDivisibleAmount(1000000, true));
+    BOOST_CHECK("+0.10000000" == FormatDivisibleAmount(10000000, true));
+    BOOST_CHECK("+1.00000000" == FormatDivisibleAmount(100000000, true));
+    BOOST_CHECK("+10.00000000" == FormatDivisibleAmount(1000000000, true));
+    BOOST_CHECK("+100.00000000" == FormatDivisibleAmount(10000000000, true));
+    BOOST_CHECK("+1000.00000000" == FormatDivisibleAmount(100000000000, true));
+    BOOST_CHECK("+10000.00000000" == FormatDivisibleAmount(1000000000000, true));
+    BOOST_CHECK("+100000.00000000" == FormatDivisibleAmount(10000000000000, true));
+    BOOST_CHECK("+1000000.00000000" == FormatDivisibleAmount(100000000000000, true));
+    BOOST_CHECK("+10000000.00000000" == FormatDivisibleAmount(1000000000000000, true));
+    BOOST_CHECK("+100000000.00000000" == FormatDivisibleAmount(10000000000000000, true));
+    BOOST_CHECK("+1000000000.00000000" == FormatDivisibleAmount(100000000000000000, true));
+    BOOST_CHECK("+10000000000.00000000" == FormatDivisibleAmount(1000000000000000000, true));
+
+    // negative numbers
+    BOOST_CHECK("-0.00000001" == FormatDivisibleAmount(-1, true));
+    BOOST_CHECK("-0.00000010" == FormatDivisibleAmount(-10, true));
+    BOOST_CHECK("-0.00000100" == FormatDivisibleAmount(-100, true));
+    BOOST_CHECK("-0.00001000" == FormatDivisibleAmount(-1000, true));
+    BOOST_CHECK("-0.00010000" == FormatDivisibleAmount(-10000, true));
+    BOOST_CHECK("-0.00100000" == FormatDivisibleAmount(-100000, true));
+    BOOST_CHECK("-0.01000000" == FormatDivisibleAmount(-1000000, true));
+    BOOST_CHECK("-0.10000000" == FormatDivisibleAmount(-10000000, true));
+    BOOST_CHECK("-1.00000000" == FormatDivisibleAmount(-100000000, true));
+    BOOST_CHECK("-10.00000000" == FormatDivisibleAmount(-1000000000, true));
+    BOOST_CHECK("-100.00000000" == FormatDivisibleAmount(-10000000000, true));
+    BOOST_CHECK("-1000.00000000" == FormatDivisibleAmount(-100000000000, true));
+    BOOST_CHECK("-10000.00000000" == FormatDivisibleAmount(-1000000000000, true));
+    BOOST_CHECK("-100000.00000000" == FormatDivisibleAmount(-10000000000000, true));
+    BOOST_CHECK("-1000000.00000000" == FormatDivisibleAmount(-100000000000000, true));
+    BOOST_CHECK("-10000000.00000000" == FormatDivisibleAmount(-1000000000000000, true));
+    BOOST_CHECK("-100000000.00000000" == FormatDivisibleAmount(-10000000000000000, true));
+    BOOST_CHECK("-1000000000.00000000" == FormatDivisibleAmount(-100000000000000000, true));
+    BOOST_CHECK("-10000000000.00000000" == FormatDivisibleAmount(-1000000000000000000, true));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_unsigned)
+{
+    // positive numbers
+    BOOST_CHECK("0.00000000" == FormatDivisibleAmount(0, false));
+    BOOST_CHECK("0.00000001" == FormatDivisibleAmount(1, false));
+    BOOST_CHECK("0.00000010" == FormatDivisibleAmount(10, false));
+    BOOST_CHECK("0.00000100" == FormatDivisibleAmount(100, false));
+    BOOST_CHECK("0.00001000" == FormatDivisibleAmount(1000, false));
+    BOOST_CHECK("0.00010000" == FormatDivisibleAmount(10000, false));
+    BOOST_CHECK("0.00100000" == FormatDivisibleAmount(100000, false));
+    BOOST_CHECK("0.01000000" == FormatDivisibleAmount(1000000, false));
+    BOOST_CHECK("0.10000000" == FormatDivisibleAmount(10000000, false));
+    BOOST_CHECK("1.00000000" == FormatDivisibleAmount(100000000, false));
+    BOOST_CHECK("10.00000000" == FormatDivisibleAmount(1000000000, false));
+    BOOST_CHECK("100.00000000" == FormatDivisibleAmount(10000000000, false));
+    BOOST_CHECK("1000.00000000" == FormatDivisibleAmount(100000000000, false));
+    BOOST_CHECK("10000.00000000" == FormatDivisibleAmount(1000000000000, false));
+    BOOST_CHECK("100000.00000000" == FormatDivisibleAmount(10000000000000, false));
+    BOOST_CHECK("1000000.00000000" == FormatDivisibleAmount(100000000000000, false));
+    BOOST_CHECK("10000000.00000000" == FormatDivisibleAmount(1000000000000000, false));
+    BOOST_CHECK("100000000.00000000" == FormatDivisibleAmount(10000000000000000, false));
+    BOOST_CHECK("1000000000.00000000" == FormatDivisibleAmount(100000000000000000, false));
+    BOOST_CHECK("10000000000.00000000" == FormatDivisibleAmount(1000000000000000000, false));
+
+    // negative numbers
+    BOOST_CHECK("0.00000001" == FormatDivisibleAmount(-1, false));
+    BOOST_CHECK("0.00000010" == FormatDivisibleAmount(-10, false));
+    BOOST_CHECK("0.00000100" == FormatDivisibleAmount(-100, false));
+    BOOST_CHECK("0.00001000" == FormatDivisibleAmount(-1000, false));
+    BOOST_CHECK("0.00010000" == FormatDivisibleAmount(-10000, false));
+    BOOST_CHECK("0.00100000" == FormatDivisibleAmount(-100000, false));
+    BOOST_CHECK("0.01000000" == FormatDivisibleAmount(-1000000, false));
+    BOOST_CHECK("0.10000000" == FormatDivisibleAmount(-10000000, false));
+    BOOST_CHECK("1.00000000" == FormatDivisibleAmount(-100000000, false));
+    BOOST_CHECK("10.00000000" == FormatDivisibleAmount(-1000000000, false));
+    BOOST_CHECK("100.00000000" == FormatDivisibleAmount(-10000000000, false));
+    BOOST_CHECK("1000.00000000" == FormatDivisibleAmount(-100000000000, false));
+    BOOST_CHECK("10000.00000000" == FormatDivisibleAmount(-1000000000000, false));
+    BOOST_CHECK("100000.00000000" == FormatDivisibleAmount(-10000000000000, false));
+    BOOST_CHECK("1000000.00000000" == FormatDivisibleAmount(-100000000000000, false));
+    BOOST_CHECK("10000000.00000000" == FormatDivisibleAmount(-1000000000000000, false));
+    BOOST_CHECK("100000000.00000000" == FormatDivisibleAmount(-10000000000000000, false));
+    BOOST_CHECK("1000000000.00000000" == FormatDivisibleAmount(-100000000000000000, false));
+    BOOST_CHECK("10000000000.00000000" == FormatDivisibleAmount(-1000000000000000000, false));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_indivisible_limits)
+{
+    BOOST_CHECK("9223372036854775807" == FormatIndivisibleAmount(9223372036854775807));
+    BOOST_CHECK("-9223372036854775807" == FormatIndivisibleAmount(-9223372036854775807));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_unsigned_limits)
+{
+    BOOST_CHECK("92233720368.54775807" == FormatDivisibleAmount(9223372036854775807));
+    BOOST_CHECK("-92233720368.54775807" == FormatDivisibleAmount(-9223372036854775807));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_signed_limits)
+{
+    BOOST_CHECK("+92233720368.54775807" == FormatDivisibleAmount(9223372036854775807, true));
+    BOOST_CHECK("-92233720368.54775807" == FormatDivisibleAmount(-9223372036854775807, true));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_token_amount_divisible)
+{
+    BOOST_CHECK("9223372036854775807" == FormatTokenAmount(9223372036854775807, false));
+    BOOST_CHECK("-9223372036854775807" == FormatTokenAmount(-9223372036854775807, false));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_token_amount_indivisible)
+{
+    BOOST_CHECK("92233720368.54775807" == FormatTokenAmount(9223372036854775807, true));
+    BOOST_CHECK("-92233720368.54775807" == FormatTokenAmount(-9223372036854775807, true));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_amounts_auto_sign)
+{
+    BOOST_CHECK("1" == FormatTokenAmount(1));
+    BOOST_CHECK("-1" == FormatTokenAmount(-1));
+
+    BOOST_CHECK("0.00000001" == FormatDivisibleAmount(1));
+    BOOST_CHECK("-0.00000001" == FormatDivisibleAmount(-1));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mastercore_format_tests.cpp
+++ b/src/test/mastercore_format_tests.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(mastercore_format_indivisible)
     BOOST_CHECK("-1000000000000000000" == FormatIndivisibleAmount(-1000000000000000000));
 }
 
-BOOST_AUTO_TEST_CASE(mastercore_format_divisible_signed)
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_with_sign)
 {
     // positive numbers
     BOOST_CHECK("+0.00000000" == FormatDivisibleAmount(0, true));
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(mastercore_format_divisible_signed)
     BOOST_CHECK("-10000000000.00000000" == FormatDivisibleAmount(-1000000000000000000, true));
 }
 
-BOOST_AUTO_TEST_CASE(mastercore_format_divisible_unsigned)
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_without_sign)
 {
     // positive numbers
     BOOST_CHECK("0.00000000" == FormatDivisibleAmount(0, false));
@@ -152,25 +152,25 @@ BOOST_AUTO_TEST_CASE(mastercore_format_indivisible_limits)
     BOOST_CHECK("-9223372036854775807" == FormatIndivisibleAmount(-9223372036854775807));
 }
 
-BOOST_AUTO_TEST_CASE(mastercore_format_divisible_unsigned_limits)
-{
-    BOOST_CHECK("92233720368.54775807" == FormatDivisibleAmount(9223372036854775807));
-    BOOST_CHECK("-92233720368.54775807" == FormatDivisibleAmount(-9223372036854775807));
-}
-
-BOOST_AUTO_TEST_CASE(mastercore_format_divisible_signed_limits)
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_limits_with_sign)
 {
     BOOST_CHECK("+92233720368.54775807" == FormatDivisibleAmount(9223372036854775807, true));
     BOOST_CHECK("-92233720368.54775807" == FormatDivisibleAmount(-9223372036854775807, true));
 }
 
-BOOST_AUTO_TEST_CASE(mastercore_format_token_amount_divisible)
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_limits_without_sign)
+{
+    BOOST_CHECK("92233720368.54775807" == FormatDivisibleAmount(9223372036854775807, false));
+    BOOST_CHECK("92233720368.54775807" == FormatDivisibleAmount(-9223372036854775807, false));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_token_amount_limits_divisible)
 {
     BOOST_CHECK("9223372036854775807" == FormatTokenAmount(9223372036854775807, false));
     BOOST_CHECK("-9223372036854775807" == FormatTokenAmount(-9223372036854775807, false));
 }
 
-BOOST_AUTO_TEST_CASE(mastercore_format_token_amount_indivisible)
+BOOST_AUTO_TEST_CASE(mastercore_format_token_amount_limits_indivisible)
 {
     BOOST_CHECK("92233720368.54775807" == FormatTokenAmount(9223372036854775807, true));
     BOOST_CHECK("-92233720368.54775807" == FormatTokenAmount(-9223372036854775807, true));
@@ -181,8 +181,53 @@ BOOST_AUTO_TEST_CASE(mastercore_format_amounts_auto_sign)
     BOOST_CHECK("1" == FormatTokenAmount(1));
     BOOST_CHECK("-1" == FormatTokenAmount(-1));
 
+    BOOST_CHECK("1" == FormatIndivisibleAmount(1));
+    BOOST_CHECK("-1" == FormatIndivisibleAmount(-1));
+
     BOOST_CHECK("0.00000001" == FormatDivisibleAmount(1));
     BOOST_CHECK("-0.00000001" == FormatDivisibleAmount(-1));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_indivisible_conversion)
+{
+    // positive numbers
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<uint8_t>(42)));
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<uint16_t>(42)));
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<uint32_t>(42)));
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<uint64_t>(42)));
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<float>(42)));
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<double>(42)));
+    BOOST_CHECK_EQUAL("42", FormatIndivisibleAmount(static_cast<long double>(42)));
+
+    // negative numbers
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<int8_t>(-42)));
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<int16_t>(-42)));
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<int32_t>(-42)));
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<int64_t>(-42)));
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<float>(-42)));
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<double>(-42)));
+    BOOST_CHECK_EQUAL("-42", FormatIndivisibleAmount(static_cast<long double>(-42)));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_format_divisible_conversion)
+{
+    // positive numbers
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<uint8_t>(42)));
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<uint16_t>(42)));
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<uint32_t>(42)));
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<uint64_t>(42)));
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<float>(42)));
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<double>(42)));
+    BOOST_CHECK_EQUAL("0.00000042", FormatDivisibleAmount(static_cast<long double>(42)));
+
+    // negative numbers
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<int8_t>(-42)));
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<int16_t>(-42)));
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<int32_t>(-42)));
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<int64_t>(-42)));
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<float>(-42)));
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<double>(-42)));
+    BOOST_CHECK_EQUAL("-0.00000042", FormatDivisibleAmount(static_cast<long double>(-42)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Renamed FormatDivisibleMP to FormatDivisibleAmount
- Renamed FormatIndivisibleMP to FormatIndivisibleAmount
- Added FormatTokenAmount
- Format_Amount is now in namespace mastercore
- Format_Amount is available via mastercore_parse_string.h
- Old behavior not changed, but enhanced

FormatDivisibleAmount(int64_t n) and FormatIndivisibleAmount(int64_t n) without second parameter convert and format a number to string and add minus sign for _negative_ numbers. If there is a use-case to enforce or suppress a sign (positive or negative), the second parameter can be used.

FormatTokenAmount(int64_t n) and FormatTokenAmount(int64_t n, bool divisible) add a minus sign for negative numbers and no sign for positive numbers. Per default (no second paramter provided) the result represents an indivisible amount.

There are quite a few lines which can be simplified, such as:

``` c
std::string strAmount;

if (divisible)
    strAmount = FormatDivisibleMP(nTokens);
else
    strAmount = FormatIndivisibleMP(nTokens);
```

To:

``` c++
std::string strAmount = FormatTokenAmount(nTokens, divisible);
```
