### PR TITLE
Move rounduint64, swapByteOrderN, test and "fix" rounduint64

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,7 @@ BITCOIN_CORE_H = \
   compat.h \
   core.h \
   mastercore.h \
+  mastercore_convert.h \
   mastercore_parse_string.h \
   mastercore_tx.h \
   mastercore_dex.h \
@@ -132,6 +133,7 @@ libbitcoin_common_a_SOURCES = \
   chainparams.cpp \
   core.cpp \
   mastercore.cpp \
+  mastercore_convert.cpp \
   mastercore_parse_string.cpp \
   mastercore_tx.cpp \
   mastercore_rpc.cpp \

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2568,13 +2568,6 @@ int64_t feeCheck(const string &address)
     return selectCoins(address, coinControl, 0);
 }
 
-#define PUSH_BACK_BYTES(vector, value)\
-    vector.insert(vector.end(), reinterpret_cast<unsigned char *>(&(value)), reinterpret_cast<unsigned char *>(&(value)) + sizeof((value)));
-
-#define PUSH_BACK_BYTES_PTR(vector, ptr, size)\
-    vector.insert(vector.end(), reinterpret_cast<unsigned char *>((ptr)), reinterpret_cast<unsigned char *>((ptr)) + (size));
-
-
 //
 // Do we care if this is true: pubkeys[i].IsCompressed() ???
 // returns 0 if everything is OK, the transaction was sent

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -73,6 +73,7 @@ static const string getmoney_testnet = "moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP";
 
 using namespace mastercore;
 
+#include "mastercore_convert.h"
 #include "mastercore_dex.h"
 #include "mastercore_tx.h"
 #include "mastercore_sp.h"
@@ -354,11 +355,6 @@ void swapByteOrder64(uint64_t& ull)
           ((ull>>24) & 0x0000000000FF0000) |
           ((ull>>40) & 0x000000000000FF00) |
           (ull << 56);
-}
-
-uint64_t rounduint64(double d)
-{
-  return (uint64_t)(abs(0.5 + d));
 }
 
 bool isNonMainNet()

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -314,49 +314,6 @@ string str = "*unknown*";
   return str;
 }
 
-bool isBigEndian()
-{
-  union
-  {
-    uint32_t i;
-    char c[4];
-  } bint = {0x01020304};
-
-  return 1 == bint.c[0];
-}
-
-void swapByteOrder16(unsigned short& us)
-{
-  if (isBigEndian()) return;
-
-    us = (us >> 8) |
-         (us << 8);
-}
-
-void swapByteOrder32(unsigned int& ui)
-{
-  if (isBigEndian()) return;
-
-    ui = (ui >> 24) |
-         ((ui<<8) & 0x00FF0000) |
-         ((ui>>8) & 0x0000FF00) |
-         (ui << 24);
-}
-
-void swapByteOrder64(uint64_t& ull)
-{
-  if (isBigEndian()) return;
-
-    ull = (ull >> 56) |
-          ((ull<<40) & 0x00FF000000000000) |
-          ((ull<<24) & 0x0000FF0000000000) |
-          ((ull<<8) & 0x000000FF00000000) |
-          ((ull>>8) & 0x00000000FF000000) |
-          ((ull>>24) & 0x0000000000FF0000) |
-          ((ull>>40) & 0x000000000000FF00) |
-          (ull << 56);
-}
-
 bool isNonMainNet()
 {
   return (TestNet() || RegTest());

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -444,8 +444,6 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
 int mastercore_handler_tx(const CTransaction &tx, int nBlock, unsigned int idx, CBlockIndex const *pBlockIndex );
 int mastercore_save_state( CBlockIndex const *pBlockIndex );
 
-uint64_t rounduint64(double d);
-
 bool isBigEndian(void);
 
 void swapByteOrder16(unsigned short& us);

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -444,12 +444,6 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
 int mastercore_handler_tx(const CTransaction &tx, int nBlock, unsigned int idx, CBlockIndex const *pBlockIndex );
 int mastercore_save_state( CBlockIndex const *pBlockIndex );
 
-bool isBigEndian(void);
-
-void swapByteOrder16(unsigned short& us);
-void swapByteOrder32(unsigned int& ui);
-void swapByteOrder64(uint64_t& ull);
-
 namespace mastercore
 {
 extern std::map<string, CMPTally> mp_tally_map;

--- a/src/mastercore_convert.cpp
+++ b/src/mastercore_convert.cpp
@@ -6,9 +6,53 @@
 namespace mastercore
 {
 
+// TODO: move to seperate file with checks
+static bool isBigEndian()
+{
+  union
+  {
+    uint32_t i;
+    char c[4];
+  } bint = {0x01020304};
+
+  return 1 == bint.c[0];
+}
+
 uint64_t rounduint64(long double ld)
 {
     return static_cast<uint64_t>(roundl(fabsl(ld)));
+}
+
+void swapByteOrder16(uint16_t& us)
+{
+  if (isBigEndian()) return;
+
+    us = (us >> 8) |
+         (us << 8);
+}
+
+void swapByteOrder32(uint32_t& ui)
+{
+  if (isBigEndian()) return;
+
+    ui = (ui >> 24) |
+         ((ui << 8) & 0x00FF0000) |
+         ((ui >> 8) & 0x0000FF00) |
+         (ui << 24);
+}
+
+void swapByteOrder64(uint64_t& ull)
+{
+  if (isBigEndian()) return;
+
+    ull = (ull >> 56) |
+          ((ull << 40) & 0x00FF000000000000) |
+          ((ull << 24) & 0x0000FF0000000000) |
+          ((ull << 8)  & 0x000000FF00000000) |
+          ((ull >> 8)  & 0x00000000FF000000) |
+          ((ull >> 24) & 0x0000000000FF0000) |
+          ((ull >> 40) & 0x000000000000FF00) |
+          (ull << 56);
 }
 
 } // namespace mastercore

--- a/src/mastercore_convert.cpp
+++ b/src/mastercore_convert.cpp
@@ -6,9 +6,9 @@
 namespace mastercore
 {
 
-uint64_t rounduint64(double d)
+uint64_t rounduint64(long double ld)
 {
-    return (uint64_t)(std::abs(0.5 + d));
+    return static_cast<uint64_t>(roundl(fabsl(ld)));
 }
 
 } // namespace mastercore

--- a/src/mastercore_convert.cpp
+++ b/src/mastercore_convert.cpp
@@ -1,0 +1,14 @@
+#include "mastercore_convert.h"
+
+#include <cmath>
+#include <stdint.h>
+
+namespace mastercore
+{
+
+uint64_t rounduint64(double d)
+{
+    return (uint64_t)(std::abs(0.5 + d));
+}
+
+} // namespace mastercore

--- a/src/mastercore_convert.h
+++ b/src/mastercore_convert.h
@@ -14,6 +14,14 @@ namespace mastercore
  */
 uint64_t rounduint64(long double);
 
+/**
+ * Swaps byte order on little-endian systems and does nothing 
+ * otherwise.
+ */
+void swapByteOrder16(uint16_t&);
+void swapByteOrder32(uint32_t&);
+void swapByteOrder64(uint64_t&);
+
 } // namespace mastercore
 
 #endif // _MASTERCORE_CONVERT

--- a/src/mastercore_convert.h
+++ b/src/mastercore_convert.h
@@ -12,7 +12,7 @@ namespace mastercore
  * is greater or equal than .5, then the result is rounded
  * up and down otherwise.
  */
-uint64_t rounduint64(double);
+uint64_t rounduint64(long double);
 
 } // namespace mastercore
 

--- a/src/mastercore_convert.h
+++ b/src/mastercore_convert.h
@@ -1,0 +1,19 @@
+#ifndef _MASTERCORE_CONVERT
+#define _MASTERCORE_CONVERT
+
+#include <stdint.h>
+
+namespace mastercore
+{
+
+/**
+ * Converts numbers to 64 bit wide unsigned integer whereby
+ * any signedness is ignored. If absolute value of the number
+ * is greater or equal than .5, then the result is rounded
+ * up and down otherwise.
+ */
+uint64_t rounduint64(double);
+
+} // namespace mastercore
+
+#endif // _MASTERCORE_CONVERT

--- a/src/mastercore_convert.h
+++ b/src/mastercore_convert.h
@@ -16,7 +16,7 @@ uint64_t rounduint64(long double);
 
 /**
  * Swaps byte order on little-endian systems and does nothing 
- * otherwise.
+ * otherwise. swapByteOrder cycles on LE systems.
  */
 void swapByteOrder16(uint16_t&);
 void swapByteOrder32(uint32_t&);
@@ -28,7 +28,7 @@ void swapByteOrder64(uint64_t&);
 #define PUSH_BACK_BYTES(vector, value)\
     vector.insert(vector.end(), reinterpret_cast<unsigned char *>(&(value)),\
     reinterpret_cast<unsigned char *>(&(value)) + sizeof((value)));
- 
+
 /**
  * Pushes bytes to the end of a vector based on a pointer.
  */

--- a/src/mastercore_convert.h
+++ b/src/mastercore_convert.h
@@ -22,6 +22,19 @@ void swapByteOrder16(uint16_t&);
 void swapByteOrder32(uint32_t&);
 void swapByteOrder64(uint64_t&);
 
-} // namespace mastercore
+/**
+ * Pushes bytes to the end of a vector.
+ */
+#define PUSH_BACK_BYTES(vector, value)\
+    vector.insert(vector.end(), reinterpret_cast<unsigned char *>(&(value)),\
+    reinterpret_cast<unsigned char *>(&(value)) + sizeof((value)));
+ 
+/**
+ * Pushes bytes to the end of a vector based on a pointer.
+ */
+#define PUSH_BACK_BYTES_PTR(vector, ptr, size)\
+    vector.insert(vector.end(), reinterpret_cast<unsigned char *>((ptr)),\
+    reinterpret_cast<unsigned char *>((ptr)) + (size));
+}
 
 #endif // _MASTERCORE_CONVERT

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -54,6 +54,7 @@ using namespace leveldb;
 
 using namespace mastercore;
 
+#include "mastercore_convert.h"
 #include "mastercore_dex.h"
 #include "mastercore_tx.h"
 

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -34,6 +34,7 @@ using namespace json_spirit;
 
 using namespace mastercore;
 
+#include "mastercore_convert.h"
 #include "mastercore_dex.h"
 #include "mastercore_parse_string.h"
 #include "mastercore_tx.h"

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -47,6 +47,7 @@ using namespace leveldb;
 
 using namespace mastercore;
 
+#include "mastercore_convert.h"
 #include "mastercore_dex.h"
 #include "mastercore_tx.h"
 #include "mastercore_sp.h"

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -49,6 +49,7 @@ test_bitcoin_SOURCES = \
   main_tests.cpp \
   mastercore_rounduint64_tests.cpp \
   mastercore_strtoint64_tests.cpp \
+  mastercore_swapbyteorder_tests.cpp \
   miner_tests.cpp \
   mruset_tests.cpp \
   multisig_tests.cpp \

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -47,6 +47,7 @@ test_bitcoin_SOURCES = \
   getarg_tests.cpp \
   key_tests.cpp \
   main_tests.cpp \
+  mastercore_rounduint64_tests.cpp \
   mastercore_strtoint64_tests.cpp \
   miner_tests.cpp \
   mruset_tests.cpp \

--- a/src/test/mastercore_rounduint64_tests.cpp
+++ b/src/test/mastercore_rounduint64_tests.cpp
@@ -1,0 +1,143 @@
+#include "mastercore_convert.h"
+
+#include <stdint.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(mastercore_rounduint64_tests)
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_simple)
+{
+    const int64_t COIN = 100000000;
+    double unit_price = 23.45678923999;
+    BOOST_CHECK_EQUAL(UINT64_C(2345678924), rounduint64(COIN * unit_price));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_whole_units)
+{
+    BOOST_CHECK_EQUAL(UINT64_C(0), rounduint64(0.0));
+    BOOST_CHECK_EQUAL(UINT64_C(1), rounduint64(1.0));
+    BOOST_CHECK_EQUAL(UINT64_C(2), rounduint64(2.0));
+    BOOST_CHECK_EQUAL(UINT64_C(3), rounduint64(3.0));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_round_below_point_5)
+{    
+    BOOST_CHECK_EQUAL(UINT64_C(0), rounduint64(0.49999999));
+    BOOST_CHECK_EQUAL(UINT64_C(1), rounduint64(1.49999999));
+    BOOST_CHECK_EQUAL(UINT64_C(2), rounduint64(2.49999999));
+    BOOST_CHECK_EQUAL(UINT64_C(3), rounduint64(3.49999999));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_round_point_5)
+{    
+    BOOST_CHECK_EQUAL(UINT64_C(1), rounduint64(0.5));
+    BOOST_CHECK_EQUAL(UINT64_C(2), rounduint64(1.5));
+    BOOST_CHECK_EQUAL(UINT64_C(3), rounduint64(2.5));
+    BOOST_CHECK_EQUAL(UINT64_C(4), rounduint64(3.5));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_round_over_point_5)
+{    
+    BOOST_CHECK_EQUAL(UINT64_C(1), rounduint64(0.50000001));
+    BOOST_CHECK_EQUAL(UINT64_C(2), rounduint64(1.50000001));
+    BOOST_CHECK_EQUAL(UINT64_C(3), rounduint64(2.50000001));
+    BOOST_CHECK_EQUAL(UINT64_C(4), rounduint64(3.50000001));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_limits)
+{    
+    BOOST_CHECK_EQUAL( // 1 byte signed
+            UINT64_C(127),
+            rounduint64(127.0));    
+    BOOST_CHECK_EQUAL( // 1 byte unsigned
+            UINT64_C(255),
+            rounduint64(255.0));    
+    BOOST_CHECK_EQUAL( // 2 byte signed
+            UINT64_C(32767),
+            rounduint64(32767.0));    
+    BOOST_CHECK_EQUAL( // 2 byte unsigned
+            UINT64_C(65535),
+            rounduint64(65535.0));    
+    BOOST_CHECK_EQUAL( // 4 byte signed
+            UINT64_C(2147483647),
+            rounduint64(2147483647.0));    
+    BOOST_CHECK_EQUAL( // 4 byte unsigned
+            UINT64_C(4294967295),
+            rounduint64(4294967295.0L));    
+    BOOST_CHECK_EQUAL( // 8 byte signed
+            UINT64_C(9223372036854775807),
+            rounduint64(9223372036854775807.0L));    
+    BOOST_CHECK_EQUAL( // 8 byte unsigned
+            UINT64_C(18446744073709551615),
+            rounduint64(18446744073709551615.0L));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_types)
+{
+    BOOST_CHECK_EQUAL(
+            rounduint64(static_cast<float>(1.23456789)),
+            rounduint64(static_cast<float>(1.23456789)));
+    BOOST_CHECK_EQUAL(
+            rounduint64(static_cast<float>(1.23456789)),
+            rounduint64(static_cast<double>(1.23456789)));
+    BOOST_CHECK_EQUAL(
+            rounduint64(static_cast<float>(1.23456789)),
+            rounduint64(static_cast<long double>(1.23456789)));
+    BOOST_CHECK_EQUAL(
+            rounduint64(static_cast<double>(1.23456789)),
+            rounduint64(static_cast<double>(1.23456789)));
+    BOOST_CHECK_EQUAL(
+            rounduint64(static_cast<double>(1.23456789)),
+            rounduint64(static_cast<long double>(1.23456789)));
+    BOOST_CHECK_EQUAL(
+            rounduint64(static_cast<long double>(1.23456789)),
+            rounduint64(static_cast<long double>(1.23456789)));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_promotion)
+{
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<int8_t>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<uint8_t>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<int16_t>(42)));    
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<uint16_t>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<int32_t>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<uint32_t>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<int64_t>(42)));    
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<uint64_t>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<float>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<double>(42)));
+    BOOST_CHECK_EQUAL(UINT64_C(42), rounduint64(static_cast<long double>(42)));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_absolute)
+{
+    BOOST_CHECK_EQUAL(
+            rounduint64(-128.0f),
+            rounduint64(128.0f));
+    BOOST_CHECK_EQUAL(
+            rounduint64(-32768.0),
+            rounduint64(32768.0));
+    BOOST_CHECK_EQUAL(
+            rounduint64(-65536.0),
+            rounduint64(65536.0));
+    BOOST_CHECK_EQUAL(
+            rounduint64(-2147483648.0L),
+            rounduint64(2147483648.0L));
+    BOOST_CHECK_EQUAL(            
+            rounduint64(-4294967296.0L),
+            rounduint64(4294967296.0L));
+    BOOST_CHECK_EQUAL(
+            rounduint64(-9223372036854775807.0L),
+            rounduint64(9223372036854775807.0L));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_rounduint64_special_cases)
+{    
+    BOOST_CHECK_EQUAL(UINT64_C(0), rounduint64(static_cast<double>(0.49999999999999994)));
+    BOOST_CHECK_EQUAL(UINT64_C(2147483648), rounduint64(static_cast<int32_t>(-2147483648)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mastercore_swapbyteorder_tests.cpp
+++ b/src/test/mastercore_swapbyteorder_tests.cpp
@@ -1,0 +1,88 @@
+#include "mastercore_convert.h"
+
+#include <endian.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mastercore;
+
+BOOST_AUTO_TEST_SUITE(mastercore_swapbyteorder_tests)
+
+BOOST_AUTO_TEST_CASE(mastercore_swapbyteorder_should_be_equal)
+{
+    uint16_t a = 258; 
+    uint32_t b = 16909060; 
+    uint64_t c = 722385979038285;
+
+    swapByteOrder16(a);
+    swapByteOrder32(b);
+    swapByteOrder64(c);
+
+    BOOST_CHECK_EQUAL(a, htobe16(258));
+    BOOST_CHECK_EQUAL(b, htobe32(16909060));
+    BOOST_CHECK_EQUAL(c, htobe64(722385979038285));
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_swapbyteorder_should_not_cycle)
+{
+    uint16_t a1 = 41959;
+    uint16_t a2 = 41959;
+    swapByteOrder16(a1);
+    swapByteOrder16(a2);
+    swapByteOrder16(a2);
+    BOOST_CHECK_EQUAL(a1, a2); // Should (?) be equal, but is not
+
+    uint32_t b1 = 16909060;
+    uint32_t b2 = 16909060;
+    swapByteOrder32(b1);
+    swapByteOrder32(b2);
+    swapByteOrder32(b2);    
+    BOOST_CHECK_EQUAL(b1, b2); // Should (?) be equal, but is not
+
+    uint64_t c1 = 722385979038285;
+    uint64_t c2 = 722385979038285;
+    swapByteOrder64(c1);
+    swapByteOrder64(c2);
+    swapByteOrder64(c2);
+    BOOST_CHECK_EQUAL(c1, c2); // Should (?) be equal, but is not
+
+    // To compare:
+    uint16_t d1 = 41959;
+    uint16_t d2 = 41959;
+    d1 = htole16(d1);
+    d2 = htole16(d2);
+    d2 = htole16(d2);
+    BOOST_CHECK_EQUAL(d1, d2);
+
+    uint32_t e1 = 16909060;
+    uint32_t e2 = 16909060;
+    e1 = htole32(e1);
+    e2 = htole32(e2);
+    e2 = htole32(e2);
+    BOOST_CHECK_EQUAL(e1, e2);
+
+    uint64_t f1 = 722385979038285;
+    uint64_t f2 = 722385979038285;
+    f1 = htole64(f1);
+    f2 = htole64(f2);
+    f2 = htole64(f2);  
+    BOOST_CHECK_EQUAL(f1, f2);
+}
+
+BOOST_AUTO_TEST_CASE(mastercore_swapbyteorder_should_differ)
+{
+    uint16_t a = 4660; 
+    uint32_t b = 305419896; 
+    uint64_t c = 1311768467463790320;
+
+    swapByteOrder16(a);
+    swapByteOrder32(b);
+    swapByteOrder64(c);
+
+    // swapByteOrder should convert to big endian, htole explicitly converts to little endian
+    BOOST_CHECK(a != htole16(4660));
+    BOOST_CHECK(b != htole32(305419896));
+    BOOST_CHECK(c != htole64(1311768467463790320));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- rounduint64 fixed (imho)
- rounduint64 and swapByteOrderN are available via mastercore_convert.h
- both are in the namespace mastercore

Regarding the downsides of (old) rounduint64 see #178. Most significantly: it doesn't clip anymore and numbers >= 2147483648.0 are accepted. Negative numbers have a similar behavior like positive numbers, whereby this wasn't used at all until now:

``` c++
rounduint64(-0.00000000) = rounduint64(0.00000000) = 0
rounduint64(-1.00000000) = rounduint64(1.00000000) = 1
rounduint64(-2.00000000) = rounduint64(2.00000000) = 2
rounduint64(-3.00000000) = rounduint64(3.00000000) = 3

rounduint64(-0.49999999) = rounduint64(0.49999999) = 0
rounduint64(-1.49999999) = rounduint64(1.49999999) = 1
rounduint64(-2.49999999) = rounduint64(2.49999999) = 2
rounduint64(-3.49999999) = rounduint64(3.49999999) = 3

rounduint64(-0.50000000) = rounduint64(0.50000000) = 1
rounduint64(-1.50000000) = rounduint64(1.50000000) = 2
rounduint64(-2.50000000) = rounduint64(2.50000000) = 3
rounduint64(-3.50000000) = rounduint64(3.50000000) = 4

rounduint64(-0.50000001) = rounduint64(0.50000001) = 1
rounduint64(-1.50000001) = rounduint64(1.50000001) = 2
rounduint64(-2.50000001) = rounduint64(2.50000001) = 3
rounduint64(-3.50000001) = rounduint64(3.50000001) = 4
```
