### PR TITLE
Encapsulate code that uses wallet with #ifdef ENABLE_WALLET

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -136,7 +136,9 @@ void Shutdown()
         if (pcoinsTip)
             pcoinsTip->Flush();
         delete pcoinsTip; pcoinsTip = NULL;
+#ifdef ENABLE_WALLET
         (void) mastercore_shutdown();
+#endif
         delete pcoinsdbview; pcoinsdbview = NULL;
         delete pblocktree; pblocktree = NULL;
     }
@@ -957,11 +959,11 @@ bool AppInit2(boost::thread_group& threadGroup)
             LogPrintf("No blocks matching %s were found\n", strMatch);
         return false;
     }
-
+#ifdef ENABLE_WALLET
      if (!fTxIndex) return InitError(_("Master Core: Please use -txindex option at the command line or add txindex=1 to bitcoin.conf file !!!\n"));  // mastercore check
      uiInterface.InitMessage(_("Parsing Master Protocol Transactions..."));
      (void) mastercore_init();
-
+#endif
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET
     if (fDisableWallet) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2007,28 +2007,28 @@ bool static DisconnectTip(CValidationState &state) {
     mempool.check(pcoinsTip);
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev);
-
+#ifdef ENABLE_WALLET
     if (!fReindex)
         (void) mastercore_handler_disc_begin(GetHeight(), pindexDelete);
-
+#endif
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {
         SyncWithWallets(tx.GetHash(), tx, NULL);
     }
-
+#ifdef ENABLE_WALLET
     if (!fReindex)
         (void) mastercore_handler_disc_end(GetHeight(), pindexDelete);
-
+#endif
     return true;
 }
 
 // Connect a new block to chainActive.
 bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew) {
     assert(pindexNew->pprev == chainActive.Tip());
-
+#ifdef ENABLE_WALLET
     (void) mastercore_handler_block_begin(GetHeight(), pindexNew);
-
+#endif
     mempool.check(pcoinsTip);
     // Read block from disk.
     CBlock block;
@@ -2073,11 +2073,13 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew) {
     // ... and about transactions that got confirmed:
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {
         SyncWithWallets(tx.GetHash(), tx, &block);
+#ifdef ENABLE_WALLET
         if (0 == mastercore_handler_tx(tx, GetHeight(), tx_idx++, pindexNew )) ++countMP;
+#endif
     }
-
+#ifdef ENABLE_WALLET
     (void) mastercore_handler_block_end(GetHeight(), pindexNew, countMP);
-
+#endif
     return true;
 }
 


### PR DESCRIPTION
This compiles and works with with --disable-wallet (or --without-wallet).
