### PR TITLE
Add trade history levelDB, trade_MP call, clean up MetaDex populateRPCTransactionObject

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3085,7 +3085,7 @@ unsigned int n_found = 0;
 }
 
 // MPTradeList here
-bool CMPTradeList::getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray, uint64_t *totalBought)
+bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId, Array *tradeArray, uint64_t *totalBought)
 {
   if (!tdb) return false;
   totalBought = 0;
@@ -3119,25 +3119,26 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, string sellerAddress, A
                   string address;
                   string address1 = vstr[0];
                   string address2 = vstr[1];
+                  unsigned int prop1;
+                  unsigned int prop2;
                   unsigned int propBought;
                   unsigned int propSold;
                   uint64_t amountBought;
                   uint64_t amountSold;
-                  if (address1 == sellerAddress)
+                  prop1 = boost::lexical_cast<unsigned int>(vstr[2]);
+                  prop2 = boost::lexical_cast<unsigned int>(vstr[3]);
+
+                  if (prop1 == propertyId)
                   {
                       address = address2;
-                      propBought = boost::lexical_cast<unsigned int>(vstr[2]);
-                      propSold = boost::lexical_cast<unsigned int>(vstr[3]);
-                      amountBought = boost::lexical_cast<uint64_t>(vstr[4]);
-                      amountSold = boost::lexical_cast<uint64_t>(vstr[5]);
+                      amountBought = boost::lexical_cast<uint64_t>(vstr[5]);
+                      amountSold = boost::lexical_cast<uint64_t>(vstr[4]);
                   }
                   else
                   {
                       address = address1;
-                      propBought = boost::lexical_cast<unsigned int>(vstr[3]);
-                      propSold = boost::lexical_cast<unsigned int>(vstr[2]);
-                      amountBought = boost::lexical_cast<uint64_t>(vstr[5]);
-                      amountSold = boost::lexical_cast<uint64_t>(vstr[4]);
+                      amountBought = boost::lexical_cast<uint64_t>(vstr[4]);
+                      amountSold = boost::lexical_cast<uint64_t>(vstr[5]);
                   }
                   int blockNum = atoi(vstr[6]);
 

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2391,12 +2391,10 @@ int mastercore_shutdown()
   {
     delete p_txlistdb; p_txlistdb = NULL;
   }
-printf("here1\n");
   if (t_tradelistdb)
   {
     delete t_tradelistdb; t_tradelistdb = NULL;
   }
-printf("here2\n");
 
   if (mp_fp)
   {
@@ -3173,6 +3171,7 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId
           }
       }
   }
+  delete it;
   if (count) { return true; } else { return false; }
 }
 

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3089,7 +3089,7 @@ void CMPTradeList::recordTrade(const uint256 &txid1, const uint256 &txid2, strin
   if (!tdb) return;
 
   const string key = txid1.ToString() + txid2.ToString();
-  const string value = strprintf("%s:%s:&u:%u:%lu:%lu:%d", address1, address2, prop1, prop2, amount1, amount2, nblockNum);
+  const string value = strprintf("%s:%s:&u:%u:%lu:%lu:%d", address1, address2, prop1, prop2, amount1, amount2, blockNum);
   Status status;
   if (tdb)
   {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -114,6 +114,7 @@ int msc_debug_tally = 1;
 int msc_debug_sp    = 1;
 int msc_debug_sto   = 1;
 int msc_debug_txdb  = 0;
+int msc_debug_tradedb = 1;
 int msc_debug_persistence = 0;
 int msc_debug_metadex = 1;
 int msc_debug_metadex2= 1;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2391,11 +2391,12 @@ int mastercore_shutdown()
   {
     delete p_txlistdb; p_txlistdb = NULL;
   }
-
+printf("here1\n");
   if (t_tradelistdb)
   {
     delete t_tradelistdb; t_tradelistdb = NULL;
   }
+printf("here2\n");
 
   if (mp_fp)
   {
@@ -3123,8 +3124,8 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId
                   string address2 = vstr[1];
                   unsigned int prop1;
                   unsigned int prop2;
-                  unsigned int propBought;
-                  unsigned int propSold;
+                  uint64_t uAmount1;
+                  uint64_t uAmount2;
                   uint64_t nBought;
                   string amountBought;
                   string amountSold;
@@ -3132,15 +3133,16 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId
                   string amount2;
                   prop1 = boost::lexical_cast<unsigned int>(vstr[2]);
                   prop2 = boost::lexical_cast<unsigned int>(vstr[3]);
-printf("propertyid %d   prop1 %d   prop2 %d\n",propertyId,prop1,prop2);
+                  uAmount1 = boost::lexical_cast<uint64_t>(vstr[4]);
+                  uAmount2 = boost::lexical_cast<uint64_t>(vstr[5]);
                   if(isPropertyDivisible(prop1))
-                     { amount1 = FormatDivisibleMP(boost::lexical_cast<uint64_t>(vstr[4])); }
+                     { amount1 = FormatDivisibleMP(uAmount1); }
                   else
-                     { amount1 = FormatIndivisibleMP(boost::lexical_cast<uint64_t>(vstr[4])); }
+                     { amount1 = FormatIndivisibleMP(uAmount1); }
                   if(isPropertyDivisible(prop2))
-                     { amount2 = FormatDivisibleMP(boost::lexical_cast<uint64_t>(vstr[5])); }
+                     { amount2 = FormatDivisibleMP(uAmount2); }
                   else
-                     { amount2 = FormatIndivisibleMP(boost::lexical_cast<uint64_t>(vstr[5])); }
+                     { amount2 = FormatIndivisibleMP(uAmount2); }
 
                   // correct orientation of trade
                   if (prop1 == propertyId)
@@ -3158,15 +3160,12 @@ printf("propertyid %d   prop1 %d   prop2 %d\n",propertyId,prop1,prop2);
                       nBought = boost::lexical_cast<uint64_t>(vstr[4]);
                   }
                   int blockNum = atoi(vstr[6]);
-
                   Object trade;
                   trade.push_back(Pair("txid", matchTxid));
                   trade.push_back(Pair("address", address));
                   trade.push_back(Pair("block", blockNum));
-                  
                   trade.push_back(Pair("amountsold", amountSold));
                   trade.push_back(Pair("amountbought", amountBought));
-                  trade.push_back(Pair("price", FormatDivisibleMP(1)));
                   tradeArray->push_back(trade);
                   ++count;
                   totalBought=totalBought + nBought;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3085,12 +3085,11 @@ unsigned int n_found = 0;
 }
 
 // MPTradeList here
-void CMPTradeList::recordTrade(const uint256 &txid1, const uint256 &txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum)
+void CMPTradeList::recordTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum)
 {
   if (!tdb) return;
-
   const string key = txid1.ToString() + txid2.ToString();
-  const string value = strprintf("%s:%s:&u:%u:%lu:%lu:%d", address1, address2, prop1, prop2, amount1, amount2, blockNum);
+  const string value = strprintf("%s:%s:%u:%u:%lu:%lu:%d", address1, address2, prop1, prop2, amount1, amount2, blockNum);
   Status status;
   if (tdb)
   {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -151,6 +151,7 @@ static const int txRestrictionsRules[][3] = {
 };
 
 CMPTxList *mastercore::p_txlistdb;
+CMPTradeList *mastercore::t_tradelistdb;
 
 // a copy from main.cpp -- unfortunately that one is in a private namespace
 int mastercore::GetHeight()
@@ -2289,6 +2290,7 @@ int mastercore_init()
     exodus_address = exodus_testnet;
   }*/
 
+  t_tradelistdb = new CMPTradeList(GetDataDir() / "MP_tradelist", 1<<20, false, fReindex);
   p_txlistdb = new CMPTxList(GetDataDir() / "MP_txlist", 1<<20, false, fReindex);
   _my_sps = new CMPSPInfo(GetDataDir() / "MP_spinfo");
   MPPersistencePath = GetDataDir() / "MP_persist";
@@ -2385,6 +2387,11 @@ int mastercore_shutdown()
   if (p_txlistdb)
   {
     delete p_txlistdb; p_txlistdb = NULL;
+  }
+
+  if (t_tradelistdb)
+  {
+    delete t_tradelistdb; t_tradelistdb = NULL;
   }
 
   if (mp_fp)

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3125,22 +3125,37 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId
                   unsigned int prop2;
                   unsigned int propBought;
                   unsigned int propSold;
-                  uint64_t amountBought;
-                  uint64_t amountSold;
+                  uint64_t nBought;
+                  string amountBought;
+                  string amountSold;
+                  string amount1;
+                  string amount2;
                   prop1 = boost::lexical_cast<unsigned int>(vstr[2]);
                   prop2 = boost::lexical_cast<unsigned int>(vstr[3]);
+printf("propertyid %d   prop1 %d   prop2 %d\n",propertyId,prop1,prop2);
+                  if(isPropertyDivisible(prop1))
+                     { amount1 = FormatDivisibleMP(boost::lexical_cast<uint64_t>(vstr[4])); }
+                  else
+                     { amount1 = FormatIndivisibleMP(boost::lexical_cast<uint64_t>(vstr[4])); }
+                  if(isPropertyDivisible(prop2))
+                     { amount2 = FormatDivisibleMP(boost::lexical_cast<uint64_t>(vstr[5])); }
+                  else
+                     { amount2 = FormatIndivisibleMP(boost::lexical_cast<uint64_t>(vstr[5])); }
 
+                  // correct orientation of trade
                   if (prop1 == propertyId)
                   {
                       address = address2;
-                      amountBought = boost::lexical_cast<uint64_t>(vstr[5]);
-                      amountSold = boost::lexical_cast<uint64_t>(vstr[4]);
+                      amountBought = amount2;
+                      amountSold = amount1;
+                      nBought = boost::lexical_cast<uint64_t>(vstr[5]);
                   }
                   else
                   {
                       address = address1;
-                      amountBought = boost::lexical_cast<uint64_t>(vstr[4]);
-                      amountSold = boost::lexical_cast<uint64_t>(vstr[5]);
+                      amountBought = amount1;
+                      amountSold = amount2;
+                      nBought = boost::lexical_cast<uint64_t>(vstr[4]);
                   }
                   int blockNum = atoi(vstr[6]);
 
@@ -3148,12 +3163,13 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId
                   trade.push_back(Pair("txid", matchTxid));
                   trade.push_back(Pair("address", address));
                   trade.push_back(Pair("block", blockNum));
-                  trade.push_back(Pair("amountpaid", FormatDivisibleMP(amountSold)));
-                  trade.push_back(Pair("amountbought", FormatDivisibleMP(amountBought)));
+                  
+                  trade.push_back(Pair("amountsold", amountSold));
+                  trade.push_back(Pair("amountbought", amountBought));
                   trade.push_back(Pair("price", FormatDivisibleMP(1)));
                   tradeArray->push_back(trade);
                   ++count;
-                  totalBought=totalBought + amountBought;
+                  totalBought=totalBought + nBought;
               }
           }
       }

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3085,9 +3085,10 @@ unsigned int n_found = 0;
 }
 
 // MPTradeList here
-bool CMPTradeList::getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray)
+bool CMPTradeList::getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray, uint64_t *totalBought)
 {
   if (!tdb) return false;
+  totalBought = 0;
   leveldb::Slice skey, svalue;
   unsigned int count = 0;
   std::vector<std::string> vstr;
@@ -3149,6 +3150,7 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, string sellerAddress, A
                   trade.push_back(Pair("price", FormatDivisibleMP(1)));
                   tradeArray->push_back(trade);
                   ++count;
+                  totalBought=totalBought + amountBought;
               }
           }
       }

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3085,6 +3085,34 @@ unsigned int n_found = 0;
 }
 
 // MPTradeList here
+bool CMPTradeList::getMatchingTrades(const uint256 txid, Array *tradeArray)
+{
+  if (!tdb) return false;
+  leveldb::Slice skey, svalue;
+  unsigned int count = 0;
+  std::vector<std::string> vstr;
+  string txidStr = txid.ToString();
+  int block;
+  unsigned int n_found = 0;
+  leveldb::Iterator* it = tdb->NewIterator(iteroptions);
+  for(it->SeekToFirst(); it->Valid(); it->Next())
+  {
+      skey = it->key();
+      svalue = it->value();
+      string strkey = it->key().ToString();
+      size_t txidMatch = strkey.find(txidStr);
+      if(txidMatch!=std::string::npos)
+      {
+          // we have a matching trade involving this txid
+          string strvalue = it->value().ToString();
+          boost::split(vstr, strvalue, boost::is_any_of(":"), token_compress_on);
+          printf("match\n");
+          if (7 == vstr.size()) { }
+          Object trade;
+      }
+  }
+}
+
 void CMPTradeList::recordTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum)
 {
   if (!tdb) return;

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3094,8 +3094,6 @@ bool CMPTradeList::getMatchingTrades(const uint256 txid, unsigned int propertyId
   unsigned int count = 0;
   std::vector<std::string> vstr;
   string txidStr = txid.ToString();
-  int block;
-  unsigned int n_found = 0;
   leveldb::Iterator* it = tdb->NewIterator(iteroptions);
   for(it->SeekToFirst(); it->Valid(); it->Next())
   {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3084,6 +3084,7 @@ unsigned int n_found = 0;
   return (n_found);
 }
 
+// MPTradeList here
 void CMPTradeList::recordTrade(const uint256 &txid1, const uint256 &txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum)
 {
   if (!tdb) return;
@@ -3097,6 +3098,31 @@ void CMPTradeList::recordTrade(const uint256 &txid1, const uint256 &txid2, strin
     ++tWritten;
     if (msc_debug_tradedb) fprintf(mp_fp, "%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
   }
+}
+
+void CMPTradeList::printStats()
+{
+  fprintf(mp_fp, "CMPTradeList stats: tWritten= %d , tRead= %d\n", tWritten, tRead);
+}
+
+void CMPTradeList::printAll()
+{
+  int count = 0;
+  Slice skey, svalue;
+
+  readoptions.fill_cache = false;
+
+  Iterator* it = tdb->NewIterator(readoptions);
+
+  for(it->SeekToFirst(); it->Valid(); it->Next())
+  {
+    skey = it->key();
+    svalue = it->value();
+    ++count;
+    printf("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
+  }
+
+  delete it;
 }
 
 // global wrapper, block numbers are inclusive, if ending_block is 0 top of the chain will be used

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -3083,6 +3083,21 @@ unsigned int n_found = 0;
   return (n_found);
 }
 
+void CMPTradeList::recordTrade(const uint256 &txid1, const uint256 &txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum)
+{
+  if (!tdb) return;
+
+  const string key = txid1.ToString() + txid2.ToString();
+  const string value = strprintf("%s:%s:&u:%u:%lu:%lu:%d", address1, address2, prop1, prop2, amount1, amount2, nblockNum);
+  Status status;
+  if (tdb)
+  {
+    status = tdb->Put(writeoptions, key, value);
+    ++tWritten;
+    if (msc_debug_tradedb) fprintf(mp_fp, "%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+  }
+}
+
 // global wrapper, block numbers are inclusive, if ending_block is 0 top of the chain will be used
 bool mastercore::isMPinBlockRange(int starting_block, int ending_block, bool bDeleteFound)
 {

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -302,8 +302,8 @@ protected:
     leveldb::WriteOptions syncoptions;
     leveldb::DB *tdb;
     // statistics
-    unsigned int nWritten;
-    unsigned int nRead;
+    unsigned int tWritten;
+    unsigned int tRead;
 
 public:
     CMPTradeList(const boost::filesystem::path &path, size_t nCacheSize, bool fMemory, bool fWipe):nWritten(0),nRead(0)

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -329,7 +329,7 @@ public:
     bool exists(const uint256 &txid);
     void printStats();
     void printAll();
-    bool getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray, uint64_t *totalBought);
+    bool getMatchingTrades(const uint256 txid, unsigned int propertyId, Array *tradeArray, uint64_t *totalBought);
 };
 
 /* leveldb-based storage for the list of ALL Master Protocol TXIDs (key) with validity bit & other misc data as value */

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -327,9 +327,9 @@ public:
     void recordTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum);
     int deleteAboveBlock(int blockNum);
     bool exists(const uint256 &txid);
-    //bool getTrade(const uint256 &txid, string &value);
     void printStats();
     void printAll();
+    bool getMatchingTrades(const uint256 txid, Array *tradeArray);
 };
 
 /* leveldb-based storage for the list of ALL Master Protocol TXIDs (key) with validity bit & other misc data as value */

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -329,7 +329,7 @@ public:
     //bool getTrade(const uint256 &txid, string &value);
     void printStats();
     void printAll();
-}
+};
 
 /* leveldb-based storage for the list of ALL Master Protocol TXIDs (key) with validity bit & other misc data as value */
 class CMPTxList
@@ -443,6 +443,7 @@ namespace mastercore
 {
 extern std::map<string, CMPTally> mp_tally_map;
 extern CMPTxList *p_txlistdb;
+extern CMPTradeList *t_tradelistdb;
 
 typedef std::map<uint256, CMPPending> PendingMap;
 

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -329,7 +329,7 @@ public:
     bool exists(const uint256 &txid);
     void printStats();
     void printAll();
-    bool getMatchingTrades(const uint256 txid, Array *tradeArray);
+    bool getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray);
 };
 
 /* leveldb-based storage for the list of ALL Master Protocol TXIDs (key) with validity bit & other misc data as value */

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -290,6 +290,12 @@ public:
   }
 };
 
+/* leveldb-based storage for trade history - trades will be listed here atomically with key txid1:txid2 */
+class CMPTradeList
+{
+
+}
+
 /* leveldb-based storage for the list of ALL Master Protocol TXIDs (key) with validity bit & other misc data as value */
 class CMPTxList
 {

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -325,6 +325,7 @@ public:
     }
 
     void recordTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum);
+    int deleteAboveBlock(int blockNum);
     bool exists(const uint256 &txid);
     //bool getTrade(const uint256 &txid, string &value);
     void printStats();

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -324,7 +324,7 @@ public:
       tdb = NULL;
     }
 
-    void recordTrade(const uint256 &txid1, const uint256 &txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum);
+    void recordTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum);
     bool exists(const uint256 &txid);
     //bool getTrade(const uint256 &txid, string &value);
     void printStats();

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -329,7 +329,7 @@ public:
     bool exists(const uint256 &txid);
     void printStats();
     void printAll();
-    bool getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray);
+    bool getMatchingTrades(const uint256 txid, string sellerAddress, Array *tradeArray, uint64_t *totalBought);
 };
 
 /* leveldb-based storage for the list of ALL Master Protocol TXIDs (key) with validity bit & other misc data as value */

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -306,7 +306,7 @@ protected:
     unsigned int tRead;
 
 public:
-    CMPTradeList(const boost::filesystem::path &path, size_t nCacheSize, bool fMemory, bool fWipe):nWritten(0),nRead(0)
+    CMPTradeList(const boost::filesystem::path &path, size_t nCacheSize, bool fMemory, bool fWipe):tWritten(0),tRead(0)
     {
       options.paranoid_checks = true;
       options.create_if_missing = true;

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -271,7 +271,7 @@ const XDOUBLE desprice = (1/buyersprice);
 
         if (msc_debug_metadex) fprintf(mp_fp, "==== TRADED !!! %u=%s\n", NewReturn, getTradeReturnType(NewReturn).c_str());
         // record the trade in MPTradeList
-        t_tradelistdb->recordTrade(p_older->getHash(), newo->getHash(), p_older->getAddr(), newo->getAddr(), p_older->getProperty(), newo->getProperty(), 1, 1, newo->getBlock());
+        t_tradelistdb->recordTrade(p_older->getHash(), newo->getHash(), p_older->getAddr(), newo->getAddr(), p_older->getProperty(), newo->getProperty(), buyer_amountGot, paymentAmount, newo->getBlock());
 
       if (msc_debug_metadex) fprintf(mp_fp, "++ erased old: %s\n", iitt->ToString().c_str());
       // erase the old seller element

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -270,6 +270,8 @@ const XDOUBLE desprice = (1/buyersprice);
         }
 
         if (msc_debug_metadex) fprintf(mp_fp, "==== TRADED !!! %u=%s\n", NewReturn, getTradeReturnType(NewReturn).c_str());
+        // record the trade in MPTradeList
+        t_tradelistdb->recordTrade(p_older->getHash(), newo->getHash(), p_older->getAddr(), newo->getAddr(), p_older->getProperty(), newo->getProperty(), 1, 1, newo->getBlock());
 
       if (msc_debug_metadex) fprintf(mp_fp, "++ erased old: %s\n", iitt->ToString().c_str());
       // erase the old seller element

--- a/src/mastercore_dex.h
+++ b/src/mastercore_dex.h
@@ -211,6 +211,11 @@ public:
     return pblockindex->GetBlockTime();  
   }
 
+  CMPMetaDEx():block(0),txid(0),idx(0),property(0),amount(0),desired_property(0),amount_desired(0),subaction(0)
+  {
+    addr.empty();
+  }
+
   CMPMetaDEx(const string &, int, unsigned int, uint64_t, unsigned int, uint64_t, const uint256 &, unsigned int, unsigned char);
 
   void Set(const string &, int, unsigned int, uint64_t, unsigned int, uint64_t, const uint256 &, unsigned int, unsigned char);

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -2118,8 +2118,6 @@ Value gettrade_MP(const Array& params, bool fHelp)
     // everything seems ok, now add status and get an array of matches to add to the object
     // status - is order cancelled/closed-filled/open/open-partialfilled?
     bool orderOpen = false;
-    bool orderFilled = false;
-    bool orderPartialFilled = false;
     // is the sell offer still open - need more efficient way to do this
     for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it)
     {
@@ -2137,7 +2135,7 @@ Value gettrade_MP(const Array& params, bool fHelp)
              }
         }
     }
-    txobj.push_back(Pair("orderopen", orderOpen));
+    txobj.push_back(Pair("active", orderOpen));
 
     // create array of matches
     Array tradeArray;

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -2046,12 +2046,10 @@ Value listtransactions_MP(const Array& params, bool fHelp)
 
 Value gettrade_MP(const Array& params, bool fHelp)
 {
-   // note this call has been refactored to use the singular populateRPCTransactionObject function
-
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "gettransaction_MP \"txid\"\n"
-            "\nGet detailed information about a Master Protocol transaction <txid>\n"
+            "gettrade_MP \"txid\"\n"
+            "\nGet detailed information and trade matches for a Master Protocol MetaDEx trade offer <txid>\n"
             "\nArguments:\n"
             "1. \"txid\"    (string, required) The transaction id\n"
             "\nResult:\n"

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -2110,9 +2110,13 @@ Value gettrade_MP(const Array& params, bool fHelp)
     bool orderFilled = false;
 
     //txobj->push_back(Pair("status", wtxid.GetHex()));
+
     // create array of matches
+    Array tradeArray;
+    t_tradelistdb->getMatchingTrades(hash,&tradeArray);
 
     // add array to object
+    txobj.push_back(Pair("matches", tradeArray));
 
     // return object
     return txobj;

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -2079,9 +2079,14 @@ Value gettrade_MP(const Array& params, bool fHelp)
         if (0<=mp_obj.step1())
         {
             senderAddress = mp_obj.getSender();
-            propertyId = mp_obj.getProperty();
+            if (0 == mp_obj.step2_Value())
+            {
+                propertyId = mp_obj.getProperty();
+            }
         }
     }
+    if (propertyId == 0) // something went wrong, couldn't decode property ID - bad packet?
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction");
     if (senderAddress.empty()) // something went wrong, couldn't decode transaction
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction");
 

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -2057,3 +2057,7 @@ Value listtransactions_MP(const Array& params, bool fHelp)
     return response;   // return response array for JSON serialization
 }
 
+Value gettrade_MP(const Array& params, bool fHelp)
+{
+
+}

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -131,6 +131,13 @@ int extra2 = 0, extra3 = 0;
     case 6:
       MetaDEx_debug_print();
       break;
+
+    case 7:
+      // display the whole CMPTradeList (leveldb)
+      t_tradelistdb->printAll();
+      t_tradelistdb->printStats();
+      break;
+
   }
 
   return GetHeight();

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1827,19 +1827,22 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
         txobj->push_back(Pair("fee", ValueFromAmount(nFee)));
         txobj->push_back(Pair("blocktime", blockTime));
         txobj->push_back(Pair("type", MPTxType));
-        txobj->push_back(Pair("propertyid", propertyId));
+        if (!MSC_TYPE_METADEX == MPTxTypeInt) txobj->push_back(Pair("propertyid", propertyId));
         if ((MSC_TYPE_CREATE_PROPERTY_VARIABLE == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_FIXED == MPTxTypeInt) || (MSC_TYPE_CREATE_PROPERTY_MANUAL == MPTxTypeInt))
         {
             txobj->push_back(Pair("propertyname", propertyName));
         }
         txobj->push_back(Pair("divisible", divisible));
-        if (divisible)
+        if (!MSC_TYPE_METADEX == MPTxTypeInt)
         {
-            txobj->push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
-        }
-        else
-        {
-            txobj->push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
+            if (divisible)
+            {
+                txobj->push_back(Pair("amount", FormatDivisibleMP(amount))); //divisible, format w/ bitcoins VFA func
+            }
+            else
+            {
+                txobj->push_back(Pair("amount", FormatIndivisibleMP(amount))); //indivisible, push raw 64
+            }
         }
         if (crowdPurchase)
         {
@@ -1866,18 +1869,26 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
             if (3 == sell_subaction) txobj->push_back(Pair("subaction", "Cancel"));
             txobj->push_back(Pair("bitcoindesired", ValueFromAmount(sell_btcdesired)));
         }
-        if (mdex)
+        if (MSC_TYPE_METADEX == MPTxTypeInt)
         {
-            txobj->push_back(Pair("property_owned", propertyId));
-            txobj->push_back(Pair("property_owned_divisible", mdex_propertyId_Div));
-            txobj->push_back(Pair("property_desired", mdex_propertyWanted));
-            txobj->push_back(Pair("property_desired_divisible", mdex_propertyWanted_Div));
+            string amountOffered;
+            string amountDesired;
+            if (mdex_propertyId_Div) {amountOffered=FormatDivisibleMP(amount);} else {amountOffered=FormatIndivisibleMP(amount);}
+            if (mdex_propertyWanted_Div) {amountDesired=FormatDivisibleMP(mdex_amountWanted);} else {amountDesired=FormatIndivisibleMP(mdex_amountWanted);}
+
+            txobj->push_back(Pair("amountoffered", amountOffered));
+            txobj->push_back(Pair("propertyoffered", propertyId));
+            txobj->push_back(Pair("propertyofferedisdivisible", mdex_propertyId_Div));
+            txobj->push_back(Pair("amountdesired", amountDesired));
+            txobj->push_back(Pair("propertydesired", mdex_propertyWanted));
+            txobj->push_back(Pair("propertydesiredisdivisible", mdex_propertyWanted_Div));
+            txobj->push_back(Pair("action", (uint64_t) mdex_action));
+            txobj->push_back(Pair("status", "status"));
             //txobj->push_back(Pair("unit_price", mdex_unitPrice ) );
             //txobj->push_back(Pair("inverse_unit_price", mdex_invUnitPrice ) );
             //active?
             //txobj->push_back(Pair("amount_original", FormatDivisibleMP(mdex_amt_orig_sale)));
             //txobj->push_back(Pair("amount_desired", FormatDivisibleMP(mdex_amt_des)));
-            txobj->push_back(Pair("action", (uint64_t) mdex_action));
         }
         txobj->push_back(Pair("valid", valid));
     }

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -2059,5 +2059,61 @@ Value listtransactions_MP(const Array& params, bool fHelp)
 
 Value gettrade_MP(const Array& params, bool fHelp)
 {
+   // note this call has been refactored to use the singular populateRPCTransactionObject function
 
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "gettransaction_MP \"txid\"\n"
+            "\nGet detailed information about a Master Protocol transaction <txid>\n"
+            "\nArguments:\n"
+            "1. \"txid\"    (string, required) The transaction id\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"txid\" : \"transactionid\",   (string) The transaction id\n"
+            + HelpExampleCli("gettrade_MP", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+            + HelpExampleRpc("gettrade_MP", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+        );
+
+    uint256 hash;
+    hash.SetHex(params[0].get_str());
+    Object tradeobj;
+    Object txobj;
+
+    // make a request to new RPC populator function to populate a transaction object
+    int populateResult = populateRPCTransactionObject(hash, &txobj);
+
+    // check the response, throw any error codes if false
+    if (0>populateResult)
+    {
+        // TODO: consider throwing other error codes, check back with Bitcoin Core
+        switch (populateResult)
+        {
+            case MP_TX_NOT_FOUND:
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+            case MP_TX_UNCONFIRMED:
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unconfirmed transactions are not supported");
+            case MP_BLOCK_NOT_IN_CHAIN:
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not part of the active chain");
+            case MP_CROWDSALE_WITHOUT_PROPERTY:
+                throw JSONRPCError(RPC_INTERNAL_ERROR, "Potential database corruption: \
+                                                      \"Crowdsale Purchase\" without valid property identifier");
+            case MP_INVALID_TX_IN_DB_FOUND:
+                throw JSONRPCError(RPC_INTERNAL_ERROR, "Potential database corruption: Invalid transaction found");
+            case MP_TX_IS_NOT_MASTER_PROTOCOL:
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Not a Master Protocol transaction");
+        }
+    }
+
+    // everything seems ok, now add status and get an array of matches to add to the object
+    // status - is order cancelled/filled/open?
+    bool orderOpen = false;
+    bool orderFilled = false;
+
+    //txobj->push_back(Pair("status", wtxid.GetHex()));
+    // create array of matches
+
+    // add array to object
+
+    // return object
+    return txobj;
 }

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1832,7 +1832,7 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
         {
             txobj->push_back(Pair("propertyname", propertyName));
         }
-        txobj->push_back(Pair("divisible", divisible));
+        if (!MSC_TYPE_METADEX == MPTxTypeInt) txobj->push_back(Pair("divisible", divisible));
         if (!MSC_TYPE_METADEX == MPTxTypeInt)
         {
             if (divisible)
@@ -1883,7 +1883,6 @@ static int populateRPCTransactionObject(uint256 txid, Object *txobj, string filt
             txobj->push_back(Pair("propertydesired", mdex_propertyWanted));
             txobj->push_back(Pair("propertydesiredisdivisible", mdex_propertyWanted_Div));
             txobj->push_back(Pair("action", (uint64_t) mdex_action));
-            txobj->push_back(Pair("status", "status"));
             //txobj->push_back(Pair("unit_price", mdex_unitPrice ) );
             //txobj->push_back(Pair("inverse_unit_price", mdex_invUnitPrice ) );
             //active?
@@ -2127,15 +2126,16 @@ Value gettrade_MP(const Array& params, bool fHelp)
     }
 
     // everything seems ok, now add status and get an array of matches to add to the object
-    // status - is order cancelled/filled/open?
+    // status - is order cancelled/closed-filled/open/open-partialfilled?
     bool orderOpen = false;
     bool orderFilled = false;
-
+    bool orderPartialFilled = false;
     //txobj->push_back(Pair("status", wtxid.GetHex()));
 
     // create array of matches
     Array tradeArray;
-    t_tradelistdb->getMatchingTrades(hash, senderAddress, &tradeArray);
+    uint64_t totalBought;
+    t_tradelistdb->getMatchingTrades(hash, senderAddress, &tradeArray, &totalBought);
 
     // add array to object
     txobj.push_back(Pair("matches", tradeArray));

--- a/src/qt/balancesview.cpp
+++ b/src/qt/balancesview.cpp
@@ -46,6 +46,7 @@
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 // end potentially overzealous includes
+using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
 
 #include "mastercore.h"
 using namespace mastercore;
@@ -54,7 +55,6 @@ using namespace mastercore;
 using namespace std;
 using namespace boost;
 using namespace boost::assign;
-using namespace json_spirit;
 using namespace leveldb;
 // end potentially overzealous using
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -37,6 +37,7 @@
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 // end potentially overzealous includes
+using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
 
 #include "mastercore.h"
 using namespace mastercore;
@@ -45,7 +46,6 @@ using namespace mastercore;
 using namespace std;
 using namespace boost;
 using namespace boost::assign;
-using namespace json_spirit;
 using namespace leveldb;
 // end potentially overzealous using
 

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -43,6 +43,7 @@
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 // end potentially overzealous includes
+using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
 
 #include "mastercore.h"
 using namespace mastercore;
@@ -51,7 +52,6 @@ using namespace mastercore;
 using namespace std;
 using namespace boost;
 using namespace boost::assign;
-using namespace json_spirit;
 using namespace leveldb;
 // end potentially overzealous using
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -46,6 +46,7 @@
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 // end potentially overzealous includes
+using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
 
 #include "mastercore.h"
 using namespace mastercore;
@@ -54,7 +55,6 @@ using namespace mastercore;
 using namespace std;
 using namespace boost;
 using namespace boost::assign;
-using namespace json_spirit;
 using namespace leveldb;
 // end potentially overzealous using
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -335,6 +335,7 @@ static const CRPCCommand vRPCCommands[] =
     { "gettradehistory_MP",     &gettradehistory_MP,     false,     false,      true },
     { "sendtoowners_MP",        &sendtoowners_MP,        false,     false,      true },
     { "sendrawtx_MP",           &sendrawtx_MP,           false,     false,      true },
+    { "gettrade_MP",            &gettrade_MP,            false,     false,      true },
     { "listblocktransactions_MP",       &listblocktransactions_MP,       false,     false,      true },
     { "getallbalancesforaddress_MP",    &getallbalancesforaddress_MP,    false,     false,      true },
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -203,6 +203,7 @@ extern json_spirit::Value getallbalancesforaddress_MP(const json_spirit::Array& 
 extern json_spirit::Value getactivedexsells_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
 extern json_spirit::Value gettransaction_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
 extern json_spirit::Value trade_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
+extern json_spirit::Value gettrade_MP(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getorderbook_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
 extern json_spirit::Value gettradessince_MP(const json_spirit::Array& params, bool fHelp); // in mastercore.cpp
 extern json_spirit::Value getopenorders_MP(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
1) gettransaction_MP now works for any metadex order not just open ones
2) populateRPCTransactionObject now parses off the wire for metadex just like all other types
3) new levelDB MP_tradelist
4) every _completed_ trade added to tradelistDB with txids, addresses, properties, and amounts
5) new gettrade_MP call added
6) gettrade_MP will iter metadex map to determine if offer still active
7) new getMatchedTrades function added using tradelistDB to return all trades matched with a supplied txid
8) gettrade_MP will call getMatchedTrades and supply to user over RPC
9) mscrpc 7 function to dump tradelistDB

example
http://pastie.org/pastes/9698921/text?key=a5n5cqglbd80c7tfytwgxw
