### PR TITLE
Sort trade offers and replace add_mdex_fields

### DIFF
--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1075,16 +1075,34 @@ void MetaDexObjectsToJSON(std::vector<CMPMetaDEx> vMetaDexObjs, Array& response)
         const CMPMetaDEx& obj = *it;
 
         _my_sps->getSP(obj.getProperty(), sp);
-        bool c_own_div = sp.isDivisible();
+        bool fDivisibilityProperty = sp.isDivisible();
 
         _my_sps->getSP(obj.getDesProperty(), sp);
-        bool c_want_div = sp.isDivisible();
-
-        std::string eco = isTestEcosystemProperty(obj.getProperty()) ? "Test" : "Main";
+        bool fDivisibilityDesProperty = sp.isDivisible();
         
+        // TODO: proper handling of ADD transactions
+        std::string strZeroHash; strZeroHash.resize(64, '0');        
+        std::string strTransactionHash = obj.getHash().GetHex();
+        if (strTransactionHash == strZeroHash) strTransactionHash = "ADD transaction";
+
+        std::string strAmountOriginal = FormatMP(obj.getProperty(), obj.getAmount());
+        std::string strAmountDesired = FormatMP(obj.getDesProperty(), obj.getAmountDesired());
+        std::string strEcosystem = isTestEcosystemProperty(obj.getProperty()) ? "Test" : "Main";
+  
         // add data to obj
         Object metadex_obj;
-        add_mdex_fields(&metadex_obj, obj, c_own_div, c_want_div, eco);
+        metadex_obj.push_back(Pair("address", obj.getAddr()));
+        metadex_obj.push_back(Pair("txid", strTransactionHash)); 
+        metadex_obj.push_back(Pair("ecosystem", strEcosystem));
+        metadex_obj.push_back(Pair("property_owned", (uint64_t) obj.getProperty()));
+        metadex_obj.push_back(Pair("property_desired", (uint64_t) obj.getDesProperty()));
+        metadex_obj.push_back(Pair("property_owned_divisible", fDivisibilityProperty));
+        metadex_obj.push_back(Pair("property_desired_divisible", fDivisibilityDesProperty));
+        metadex_obj.push_back(Pair("amount_original", strAmountOriginal));
+        metadex_obj.push_back(Pair("amount_desired", strAmountDesired));
+        metadex_obj.push_back(Pair("action", (int) obj.getAction()));
+        metadex_obj.push_back(Pair("block", obj.getBlock()));
+        metadex_obj.push_back(Pair("blocktime", obj.getBlockTime()));
 
         // add it to response
         response.push_back(metadex_obj);

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1081,29 +1081,6 @@ int check_prop_valid(int64_t tmpPropId, string error, string exist_error ) {
   return tmpPropId;
 }
 
-void add_mdex_fields(Object *metadex_obj, CMPMetaDEx obj, bool c_own_div, bool c_want_div, string eco) {
-
-  metadex_obj->push_back(Pair("address", obj.getAddr().c_str()));
-  metadex_obj->push_back(Pair("txid", obj.getHash().GetHex()));
-  metadex_obj->push_back(Pair("ecosystem", eco ));
-  metadex_obj->push_back(Pair("property_owned", (uint64_t) obj.getProperty()));
-  metadex_obj->push_back(Pair("property_desired", (uint64_t) obj.getDesProperty()));
-  metadex_obj->push_back(Pair("property_owned_divisible", c_own_div));
-  metadex_obj->push_back(Pair("property_desired_divisible", c_want_div));
-
-  //uint64_t *price = obj.getPrice();
-  //uint64_t *invprice = obj.getInversePrice();
-
-  //metadex_obj->push_back(Pair("unit_price", strprintf("%lu.%.8s",  price[0],  boost::lexical_cast<std::string>(price[1]) ).c_str() ) );
-  //metadex_obj->push_back(Pair("inverse_unit_price", strprintf("%lu.%.8s", invprice[0], boost::lexical_cast<std::string>(invprice[1]) ).c_str() ) );
-  //active?
-  metadex_obj->push_back(Pair("amount_original", FormatDivisibleMP(obj.getAmountForSale())));
-  metadex_obj->push_back(Pair("amount_desired", FormatDivisibleMP(obj.getAmountDesired())));
-  metadex_obj->push_back(Pair("action", (int) obj.getAction()));
-  metadex_obj->push_back(Pair("block", obj.getBlock()));
-  metadex_obj->push_back(Pair("blockTime", obj.getBlockTime()));
-}
-
 Value trade_MP(const Array& params, bool fHelp) {
 
    if (fHelp || params.size() < 6)


### PR DESCRIPTION
This is the continuation of @faizkhan00's #197.

The result of `getorderbook_MP`, `gettradessince_MP` and `gettradehistory_MP` is sorted based on block height and position of a transaction within a block by using the `MetaDEx_compare` comparator.

This further replaces `void add_mdex_fields(Object *metadex_obj, CMPMetaDEx obj, bool c_own_div, bool c_want_div, string eco)` with:

```
void MetaDexObjectToJSON(const CMPMetaDEx& obj, Object& metadex_obj)
void MetaDexObjectsToJSON(std::vector<CMPMetaDEx> vMetaDexObjs, Array& response)
```

I did not include the code / style format, but I'd be happy to push it, once this is merged.
