### PR TITLE
Change Bitcoin->MasterCore in Mac OS X places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ src/qt/test/moc*.cpp
 *.qm
 Makefile
 mastercore-qt
-Bitcoin-Qt.app
+MasterCore-Qt.app
 
 # Unit-tests
 Makefile.test

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,8 +9,8 @@ BITCOIN_QT_BIN=$(top_builddir)/src/qt/mastercore-qt$(EXEEXT)
 BITCOIN_CLI_BIN=$(top_builddir)/src/mastercore-cli$(EXEEXT)
 BITCOIN_WIN_INSTALLER=$(PACKAGE)-$(PACKAGE_VERSION)-win$(WINDOWS_BITS)-setup$(EXEEXT)
 
-OSX_APP=Bitcoin-Qt.app
-OSX_DMG=Bitcoin-Qt.dmg
+OSX_APP=MasterCore-Qt.app
+OSX_DMG=MasterCore-Qt.dmg
 OSX_DEPLOY_SCRIPT=$(top_srcdir)/contrib/macdeploy/macdeployqtplus
 OSX_FANCY_PLIST=$(top_srcdir)/contrib/macdeploy/fancy.plist
 OSX_INSTALLER_ICONS=$(top_srcdir)/src/qt/res/icons/bitcoin.icns
@@ -72,13 +72,13 @@ $(OSX_APP)/Contents/Resources/bitcoin.icns: $(OSX_INSTALLER_ICONS)
 	$(MKDIR_P) $(@D)
 	$(INSTALL_DATA) $< $@
 
-$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(BITCOIN_QT_BIN)
+$(OSX_APP)/Contents/MacOS/MasterCore-Qt: $(BITCOIN_QT_BIN)
 	$(MKDIR_P) $(@D)
 	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM)  $< $@
 
 OSX_APP_BUILT=$(OSX_APP)/Contents/PkgInfo $(OSX_APP)/Contents/Resources/empty.lproj \
   $(OSX_APP)/Contents/Resources/bitcoin.icns $(OSX_APP)/Contents/Info.plist \
-  $(OSX_APP)/Contents/MacOS/Bitcoin-Qt
+  $(OSX_APP)/Contents/MacOS/MasterCore-Qt
 
 if BUILD_DARWIN
 $(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING)
@@ -91,7 +91,7 @@ $(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING)
 	$(INSTALL) contrib/macdeploy/background.png dist/.background
 	$(INSTALL) contrib/macdeploy/DS_Store dist/.DS_Store
 	cd dist; $(LN_S) /Applications Applications
-	$(GENISOIMAGE) -no-cache-inodes -l -probe -V "Bitcoin-Qt" -no-pad -r -apple -o $@ dist
+	$(GENISOIMAGE) -no-cache-inodes -l -probe -V "MasterCore-Qt" -no-pad -r -apple -o $@ dist
 endif
 
 if TARGET_DARWIN

--- a/contrib/macdeploy/fancy.plist
+++ b/contrib/macdeploy/fancy.plist
@@ -22,7 +22,7 @@
 			<integer>370</integer>
 			<integer>156</integer>
 		</array>
-		<key>Bitcoin-Qt.app</key>
+		<key>MasterCore-Qt.app</key>
 		<array>
 			<integer>128</integer>
 			<integer>156</integer>

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -814,7 +814,7 @@ if config.dmg is not None:
                 items_positions.append(itemscript.substitute(params))
 
         params = {
-            "disk" : "Bitcoin-Qt",
+            "disk" : "MasterCore-Qt",
             "window_bounds" : "300,300,800,620",
             "icon_size" : "96",
             "background_commands" : "",

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -29,10 +29,10 @@
   <string>????</string>
 
   <key>CFBundleExecutable</key>
-  <string>Bitcoin-Qt</string>
+  <string>MasterCore-Qt</string>
 
   <key>CFBundleIdentifier</key>
-  <string>org.bitcoinfoundation.Bitcoin-Qt</string>
+  <string>org.mastercoin.MasterCore-Qt</string>
 
   <key>CFBundleURLTypes</key>
   <array>


### PR DESCRIPTION
Changes from Bitcoin to MasterCore in filenames, UI strings, etc. Necessary to build Master Core properly for OS X.

(This isn't everything needed for a working Mac OS X build, but will make it easier for others to test and contribute.)
