### PR TITLE
MetaDexObjectsToJSON: pass std::vector<CMPMetaDEx> by reference

### DIFF
--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -68,7 +68,7 @@ void MetaDexObjectToJSON(const CMPMetaDEx& obj, Object& metadex_obj)
     metadex_obj.push_back(Pair("blocktime", obj.getBlockTime()));
 }
 
-void MetaDexObjectsToJSON(std::vector<CMPMetaDEx> vMetaDexObjs, Array& response)
+void MetaDexObjectsToJSON(std::vector<CMPMetaDEx>& vMetaDexObjs, Array& response)
 {
     MetaDEx_compare compareByHeight;
     


### PR DESCRIPTION
... otherwise a copy is created each time.
