### PR TITLE
Add missing "cancel" checks, "cancel-everything" ecosystem limitation

### DIFF
--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -953,9 +953,9 @@ const CMPMetaDEx *p_mdex = NULL;
 }
 
 // scan the orderbook and remove everything for an address
-int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256 txid, unsigned int block, const string &sender_addr)
+int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256 txid, unsigned int block, const std::string &sender_addr, unsigned char ecosystem)
 {
-int rc = METADEX_ERROR -40;
+  int rc = METADEX_ERROR -40;
 
   file_log("%s()\n", __FUNCTION__);
 
@@ -966,6 +966,10 @@ int rc = METADEX_ERROR -40;
   for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it)
   {
     unsigned int prop = my_it->first;
+
+    // skip property, if it is not in the expected ecosystem
+    if (isMainEcosystemProperty(ecosystem) && !isMainEcosystemProperty(prop)) continue;
+    if (isTestEcosystemProperty(ecosystem) && !isTestEcosystemProperty(prop)) continue;    
 
     file_log(" ## property: %u\n", prop);
     md_PricesMap & prices = my_it->second;
@@ -981,7 +985,7 @@ int rc = METADEX_ERROR -40;
       {
         file_log("%s= %s\n", price.str(DISPLAY_PRECISION_LEN, std::ios_base::fixed) , it->ToString());
 
-        if ((it->getAddr() != sender_addr))
+        if (it->getAddr() != sender_addr)
         {
           ++it;
           continue;

--- a/src/mastercore_dex.h
+++ b/src/mastercore_dex.h
@@ -294,7 +294,7 @@ int DEx_payment(uint256 txid, unsigned int vout, string seller, string buyer, ui
 int MetaDEx_ADD(const string &sender_addr, unsigned int, uint64_t, int block, unsigned int property_desired, uint64_t amount_desired, const uint256 &txid, unsigned int idx);
 int MetaDEx_CANCEL_AT_PRICE(const uint256, unsigned int, const string &, unsigned int, uint64_t, unsigned int, uint64_t);
 int MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256, unsigned int, const string &, unsigned int, unsigned int);
-int MetaDEx_CANCEL_EVERYTHING(const uint256, unsigned int, const string &);
+int MetaDEx_CANCEL_EVERYTHING(const uint256 txid, unsigned int block, const std::string &sender_addr, unsigned char ecosystem);
 md_PricesMap *get_Prices(unsigned int prop);
 md_Set *get_Indexes(md_PricesMap *p, XDOUBLE price);
 

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -486,10 +486,8 @@ int rc = DEX_ERROR_ACCEPT;
 
 int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
 {
-int rc = PKT_ERROR_METADEX -100;
-unsigned char action = 0;
-
-    if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -888);
+    int rc = PKT_ERROR_METADEX -100;
+    unsigned char action = 0;
 
     memcpy(&desired_property, &pkt[16], 4);
     swapByteOrder32(desired_property);
@@ -513,46 +511,80 @@ unsigned char action = 0;
     switch (action)
     {
       case ADD:
-        if (!isTransactionTypeAllowed(block, desired_property, type, version)) return (PKT_ERROR_METADEX -889);
+      {
+        if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -889);
 
         // ensure we are not trading same property for itself
         if (property == desired_property) return (PKT_ERROR_METADEX -5);
 
-        // ensure no cross-over of currencies from Test Eco to normal
+        // ensure no cross-over of properties from test to main ecosystem
         if (isTestEcosystemProperty(property) != isTestEcosystemProperty(desired_property)) return (PKT_ERROR_METADEX -4);
 
         // ensure the desired property exists in our universe
         if (!_my_sps->hasSP(desired_property)) return (PKT_ERROR_METADEX -30);
 
-        if (!nValue) return (PKT_ERROR_METADEX -11);
-        if (!desired_value) return (PKT_ERROR_METADEX -12);
+        // ensure offered and desired values are positive
+        if (0 >= static_cast<int64_t>(nNewValue)) return (PKT_ERROR_METADEX -11);
+        if (0 >= static_cast<int64_t>(desired_value)) return (PKT_ERROR_METADEX -12);
 
         // ensure sufficient balance is available to offer
-        if (getMPbalance(sender, property, BALANCE) < (int64_t)nValue) return (PKT_ERROR_METADEX -567);
-
-        // Does the sender have any tokens?
-        if (0 >= nNewValue) return (PKT_ERROR_METADEX -3);
+        if (getMPbalance(sender, property, BALANCE) < static_cast<int64_t>(nNewValue)) return (PKT_ERROR_METADEX -567);
 
         rc = MetaDEx_ADD(sender, property, nNewValue, block, desired_property, desired_value, txid, tx_idx);
         break;
+      }
 
       case CANCEL_AT_PRICE:
-        // ensure the 4 necessary parameters for this command are provided
-        // TODO
-        // ...
+      {
+        if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -890);
+
+        // ensure we are not trading same property for itself
+        if (property == desired_property) return (PKT_ERROR_METADEX -5);
+
+        // ensure no cross-over of properties from test to main ecosystem
+        if (isTestEcosystemProperty(property) != isTestEcosystemProperty(desired_property)) return (PKT_ERROR_METADEX -4);
+
+        // ensure the desired property exists in our universe
+        if (!_my_sps->hasSP(desired_property)) return (PKT_ERROR_METADEX -30);
+
+        // ensure offered and desired values are positive
+        if (0 >= static_cast<int64_t>(nNewValue)) return (PKT_ERROR_METADEX -11);
+        if (0 >= static_cast<int64_t>(desired_value)) return (PKT_ERROR_METADEX -12);
+
         rc = MetaDEx_CANCEL_AT_PRICE(txid, block, sender, property, nNewValue, desired_property, desired_value);
         break;
+      }
 
       case CANCEL_ALL_FOR_PAIR:
-        // ensure the 2 necessary parameters for this command are provided
-        // TODO
-        // ...
+      {
+        if (!isTransactionTypeAllowed(block, property, type, version)) return (PKT_ERROR_METADEX -891);
+
+        // ensure we are not trading same property for itself
+        if (property == desired_property) return (PKT_ERROR_METADEX -5);
+
+        // ensure no cross-over of properties from test to main ecosystem
+        if (isTestEcosystemProperty(property) != isTestEcosystemProperty(desired_property)) return (PKT_ERROR_METADEX -4);
+
+        // ensure the desired property exists in our universe
+        if (!_my_sps->hasSP(desired_property)) return (PKT_ERROR_METADEX -30);
+
         rc = MetaDEx_CANCEL_ALL_FOR_PAIR(txid, block, sender, property, desired_property);
         break;
+      }
 
       case CANCEL_EVERYTHING:
-        rc = MetaDEx_CANCEL_EVERYTHING(txid, block, sender);
+      {
+        // cancel all open orders, if offered and desired properties are within the same ecosystem,
+        // otherwise cancel all open orders for all properties of both ecosystems
+        unsigned char ecosystem = 0;
+        if (isMainEcosystemProperty(property) && isMainEcosystemProperty(desired_property)) ecosystem = OMNI_PROPERTY_MSC;
+        if (isTestEcosystemProperty(property) && isTestEcosystemProperty(desired_property)) ecosystem = OMNI_PROPERTY_TMSC;
+
+        if (!isTransactionTypeAllowed(block, ecosystem, type, version, true)) return (PKT_ERROR_METADEX -892);
+
+        rc = MetaDEx_CANCEL_EVERYTHING(txid, block, sender, ecosystem);
         break;
+      }
 
       default:
         return (PKT_ERROR_METADEX -999);


### PR DESCRIPTION
- trade_MP can be used with zero amounts
- trade_MP can be used with non existing properties
- fixes behavior where raw encoded offer with zero units for sale fails, but zero units desired passes etc.
- guards and fillins of todos for "meta dex logic math"

... and cancel-everything that behaves as follows:
- both properties in main ecosystem -> cancel main properties
- both properties in test ecosystem -> cancel test properties
- cross ecosystem values (...) cancel offers of both ecosystems

Consider the last part as debatable of course.
