### PR TITLE
Add: isMainEcosystemProperty(unsigned int property)

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -499,6 +499,13 @@ bool mastercore::isTestEcosystemProperty(unsigned int property)
   return false;
 }
 
+bool mastercore::isMainEcosystemProperty(unsigned int property)
+{
+  if ((OMNI_PROPERTY_BTC != property) && !isTestEcosystemProperty(property)) return true;
+
+  return false;
+}
+
 bool mastercore::isMetaDExOfferActive(const uint256 txid, unsigned int propertyId)
 {
   for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it)

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -483,6 +483,7 @@ uint256 send_INTERNAL_1packet(const string &FromAddress, const string &ToAddress
  unsigned int PropertyID_2, uint64_t Amount_2, unsigned int TransactionType, int64_t additional, int *error_code = NULL);
 
 bool isTestEcosystemProperty(unsigned int property);
+bool isMainEcosystemProperty(unsigned int property);
 
 CMPTally *getTally(const string & address);
 


### PR DESCRIPTION
Allows to check, if a property is in the main ecosystem.

This is part of a split of #223.
