### PR TITLE
isTransactionTypeAllowed bypass for property = 0

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -848,7 +848,7 @@ void calculateFundraiser(unsigned short int propType, uint64_t amtTransfer, unsi
 // certain transaction types are not live on the network until some specific block height
 // certain transactions will be unknown to the client, i.e. "black holes" based on their version
 // the Restrictions array is as such: type, block-allowed-in, top-version-allowed
-bool mastercore::isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version)
+bool mastercore::isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty)
 {
 bool bAllowed = false;
 bool bBlackHole = false;
@@ -856,8 +856,8 @@ unsigned int type;
 int block_FirstAllowed;
 unsigned short version_TopAllowed;
 
-  // BTC as property is never allowed
-  if (OMNI_PROPERTY_BTC == txProperty) return false;
+  // bitcoin as property is never allowed, unless explicitly stated otherwise
+  if ((OMNI_PROPERTY_BTC == txProperty) && !bAllowNullProperty) return false;
 
   // everything is always allowed on Bitcoin's TestNet or with TMSC/TestEcosystem on MainNet
   if ((isNonMainNet()) || isTestEcosystemProperty(txProperty))

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -493,7 +493,7 @@ int set_wallet_totals();
 
 char *c_strMasterProtocolTXType(int i);
 
-bool isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version);
+bool isTransactionTypeAllowed(int txBlock, unsigned int txProperty, unsigned int txType, unsigned short version, bool bAllowNullProperty = false);
 
 bool getValidMPTX(const uint256 &txid, int *block = NULL, unsigned int *type = NULL, uint64_t *nAmended = NULL);
 


### PR DESCRIPTION
There are two cases where property = 0 is reasonable:
- the property value is not validated at all
- the property is indeed bitcoin and it is allowed

This is part of a split of #223.
