### PR TITLE
Allow to enable meta DEx etc. as build option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,11 @@ AC_ARG_ENABLE([glibc-back-compat],
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
+AC_ARG_ENABLE([mastercore-development],
+  [AS_HELP_STRING([--enable-mastercore-development],
+  [enable Master Core developer mode - it should not be used outside of test environments and likely results in unexpected behavior (default is no)])],
+  [enable_mastercore_devmode=$enableval],
+  [enable_mastercore_devmode=no])
 
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADERS([src/bitcoin-config.h])
@@ -586,6 +591,15 @@ else
   AC_MSG_RESULT(no)
 fi
 
+dnl enable developer mode
+AC_MSG_CHECKING([if Master Core developer mode should be enabled])
+if test x$enable_mastercore_devmode != xno; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE_UNQUOTED([MASTERCORE_DEVMODE],[1],[Define to 1 to enable Master Core developer mode])
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl enable upnp support
 AC_MSG_CHECKING([whether to build with support for UPnP])
 if test x$have_miniupnpc = xno; then
@@ -674,6 +688,7 @@ AM_CONDITIONAL([USE_LCOV],[test x$use_lcov == xyes])
 AM_CONDITIONAL([USE_COMPARISON_TOOL],[test x$use_comparison_tool != xno])
 AM_CONDITIONAL([USE_COMPARISON_TOOL_REORG_TESTS],[test x$use_comparison_tool_reorg_test != xno])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
+AM_CONDITIONAL([MASTERCORE_DEVMODE],[test x$enable_mastercore_devmode == xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -11,8 +11,6 @@
 
 #include "tinyformat.h"
 
-#define DISABLE_METADEX
-
 #define LOG_FILENAME    "mastercore.log"
 #define INFO_FILENAME   "mastercore_crowdsales.log"
 #define OWNERS_FILENAME "mastercore_owners.log"

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -94,6 +94,7 @@ void MetaDexObjectsToJSON(std::vector<CMPMetaDEx>& vMetaDexObjs, Array& response
     }
 }
 
+#if MASTERCORE_DEVMODE
 // display the tally map & the offer/accept list(s)
 Value mscrpc(const Array& params, bool fHelp)
 {
@@ -196,6 +197,7 @@ int extra2 = 0, extra3 = 0;
 
   return GetHeight();
 }
+#endif
 
 // display an MP balance via RPC
 Value getbalance_MP(const Array& params, bool fHelp)
@@ -931,7 +933,7 @@ int check_prop_valid(int64_t tmpPropId, string error, string exist_error ) {
   return tmpPropId;
 }
 
-#ifndef DISABLE_METADEX
+#ifndef MASTERCORE_DEVMODE
 Value trade_MP(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 6)

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -191,7 +191,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "listtransactions_MP"    && n > 4) ConvertTo<int64_t>(params[4]);
     if (strMethod == "getallbalancesforid_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "listblocktransactions_MP"    && n > 0) ConvertTo<int64_t>(params[0]);
-#if 0
+#if MASTERCORE_DEVMODE
     if (strMethod == "trade_MP"                && n > 2) ConvertTo<int64_t>(params[2]);
     if (strMethod == "trade_MP"                && n > 4) ConvertTo<int64_t>(params[4]);
     if (strMethod == "trade_MP"                && n > 5) ConvertTo<int64_t>(params[5]);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -316,7 +316,6 @@ static const CRPCCommand vRPCCommands[] =
     { "setgenerate",            &setgenerate,            true,      true,       false },
 
     /* Master Protocol specific calls */
-    { "mscrpc",                 &mscrpc,                 true,      false,      false },
     { "getallbalancesforid_MP", &getallbalancesforid_MP, false,     false,      true },
     { "getbalance_MP",          &getbalance_MP,          false,     false,      true },
     { "send_MP",                &send_MP,                false,     false,      true },
@@ -328,7 +327,8 @@ static const CRPCCommand vRPCCommands[] =
     { "getgrants_MP",           &getgrants_MP,           false,     false,      true },
     { "getactivedexsells_MP",   &getactivedexsells_MP,   false,     false,      true },
     { "getactivecrowdsales_MP", &getactivecrowdsales_MP, false,     false,      true },
-#if 0
+#if MASTERCORE_DEVMODE
+    { "mscrpc",                 &mscrpc,                 true,      false,      false },
     { "trade_MP",               &trade_MP,               false,     false,      true },
     { "getorderbook_MP",        &getorderbook_MP,        false,     false,      true },
     { "gettradessince_MP",      &gettradessince_MP,      false,     false,      true },


### PR DESCRIPTION
Instead of using a define in the header, provide similar behavior as build option.

The main reason for this is automatic testing, whether this is fully operational at this point or not.

It can be used as follows:

``` bash
./autogen.sh
./configure --enable-mastercore-development
make
```

---

Upfront: I don't really like it, but I'd prefer it over changing defines in the header.

As alternative I suggest to use a whole new branch, something like "0.0.9-release", which completely removes all parts that should not end up in the release version.

As second alternative this could as well be a startup parameter.
