### PR TITLE
Fire -alertnotify, shutdown with message

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -235,25 +235,30 @@ bool CAlert::ProcessAlert(bool fThread)
         if(AppliesToMe())
         {
             uiInterface.NotifyAlertChanged(GetHash(), CT_NEW);
-            std::string strCmd = GetArg("-alertnotify", "");
-            if (!strCmd.empty())
-            {
-                // Alert text should be plain ascii coming from a trusted source, but to
-                // be safe we first strip anything not in safeChars, then add single quotes around
-                // the whole string before passing it to the shell:
-                std::string singleQuote("'");
-                std::string safeStatus = SanitizeString(strStatusBar);
-                safeStatus = singleQuote+safeStatus+singleQuote;
-                boost::replace_all(strCmd, "%s", safeStatus);
-
-                if (fThread)
-                    boost::thread t(runCommand, strCmd); // thread runs free
-                else
-                    runCommand(strCmd);
-            }
+            Notify(strStatusBar, fThread);
         }
     }
 
     LogPrint("alert", "accepted alert %d, AppliesToMe()=%d\n", nID, AppliesToMe());
     return true;
+}
+
+void
+CAlert::Notify(const std::string& strMessage, bool fThread)
+{
+    std::string strCmd = GetArg("-alertnotify", "");
+    if (strCmd.empty()) return;
+
+    // Alert text should be plain ascii coming from a trusted source, but to
+    // be safe we first strip anything not in safeChars, then add single quotes around
+    // the whole string before passing it to the shell:
+    std::string singleQuote("'");
+    std::string safeStatus = SanitizeString(strMessage);
+    safeStatus = singleQuote+safeStatus+singleQuote;
+    boost::replace_all(strCmd, "%s", safeStatus);
+
+    if (fThread)
+        boost::thread t(runCommand, strCmd); // thread runs free
+    else
+        runCommand(strCmd);
 }

--- a/src/alert.h
+++ b/src/alert.h
@@ -98,7 +98,8 @@ public:
     bool AppliesToMe() const;
     bool RelayTo(CNode* pnode) const;
     bool CheckSignature() const;
-    bool ProcessAlert(bool fThread = true);
+    bool ProcessAlert(bool fThread = true); // fThread means run -alertnotify in a free-running thread
+    static void Notify(const std::string& strMessage, bool fThread);
 
     /*
      * Get copy of (active) alert object by hash. Returns a null alert if it is not found.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1375,14 +1375,9 @@ void CheckForkWarningConditions()
     {
         if (!fLargeWorkForkFound)
         {
-            std::string strCmd = GetArg("-alertnotify", "");
-            if (!strCmd.empty())
-            {
-                std::string warning = std::string("'Warning: Large-work fork detected, forking after block ") +
-                                      pindexBestForkBase->phashBlock->ToString() + std::string("'");
-                boost::replace_all(strCmd, "%s", warning);
-                boost::thread t(runCommand, strCmd); // thread runs free
-            }
+            std::string warning = std::string("'Warning: Large-work fork detected, forking after block ") +
+                pindexBestForkBase->phashBlock->ToString() + std::string("'");
+            CAlert::Notify(warning, true);
         }
         if (pindexBestForkTip)
         {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -614,7 +614,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      // can't be trusted to provide valid data, shutdown
                      std::string strMessage = strprintf("IMPORTANT NOTIFICATION: %s\n", global_alert_message);
                      file_log(strMessage);
-                     CAlert::Notify(strMessage, true); // fire warning, if -alertnotify is used
+                     CAlert::Notify(strMessage, false); // fire warning, if -alertnotify is used
                      if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode(strMessage);
                      return false;
                  }

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -13,6 +13,7 @@
 // global TODO: need locks on the maps in this file & balances (moneys[],reserved[] & raccept[]) !!!
 //
 
+#include "alert.h"
 #include "base58.h"
 #include "rpcserver.h"
 #include "init.h"
@@ -611,9 +612,10 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                  {
                      // we know we have transactions live we don't understand
                      // can't be trusted to provide valid data, shutdown
-                     file_log("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n",global_alert_message.c_str());
-                     printf("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n",global_alert_message.c_str()); //echo to screen
-                     if (!GetBoolArg("-overrideforcedshutdown", false)) StartShutdown();
+                     std::string strMessage = strprintf("IMPORTANT NOTIFICATION: %s\n", global_alert_message);
+                     file_log(strMessage);
+                     CAlert::Notify(strMessage, true); // fire warning, if -alertnotify is used
+                     if (!GetBoolArg("-overrideforcedshutdown", false)) AbortNode(strMessage);
                      return false;
                  }
 


### PR DESCRIPTION
This is no functional change and has basically no effect at this
point, because the whole alert notification system isn't active.

However, if it were, then:
- It fires the notification on shutdown as -alertnotify event
- Qt mode: on shutdown the alert message is shown in a modal window
- Daemon mode: on shutdown the notification is printed to the console
