### PR TITLE
Require Boost >= 1.53

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -404,7 +404,7 @@ if test x$use_upnp != xno; then
 fi
 
 dnl Check for boost libs
-AX_BOOST_BASE
+AX_BOOST_BASE([1.53])
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS


### PR DESCRIPTION
Boost 1.53 seems to be required for boost::multiprecision::cpp_int.

As per default Boost >= 1.20 is accepted, so this check lets a build fail earlier and with a more telling error message:

```
checking for boostlib >= 1.53... configure: We could not detect the boost libraries (version 1.53 or higher). If you have a staged boost library (still not installed) please specify $BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.
checking whether the Boost::System library is available... yes
configure: error: Could not find a version of the boost_system library!
```

Instead of:

```
  CXX    chainparams.o
  CXX    core.o
  CXX    mastercore.o
mastercore.cpp:54:44: fatal error: boost/multiprecision/cpp_int.hpp: No such file or directory
compilation terminated.
make[3]: *** [mastercore.o] Error 1
```
