### PR TITLE
Replace global balance arrays with std::map

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -85,12 +85,13 @@ static const int nBlockTop = 0;
 
 static int nWaterlineBlock = 0;  //
 
+// TODO: check, if uint64_t should be int64_t, because it referrs to balances
 uint64_t global_MSC_total = 0;
 uint64_t global_MSC_RESERVED_total = 0;
-uint64_t global_balance_money_maineco[100000];
-uint64_t global_balance_reserved_maineco[100000];
-uint64_t global_balance_money_testeco[100000];
-uint64_t global_balance_reserved_testeco[100000];
+std::map<uint32_t, uint64_t> global_balance_money_maineco;
+std::map<uint32_t, uint64_t> global_balance_reserved_maineco;
+std::map<uint32_t, uint64_t> global_balance_money_testeco;
+std::map<uint32_t, uint64_t> global_balance_reserved_testeco;
 
 string global_alert_message;
 

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -6,9 +6,10 @@
 #ifndef _MASTERCOIN
 #define _MASTERCOIN 1
 
+#include <map>
+
 #include "netbase.h"
 #include "protocol.h"
-
 #include "tinyformat.h"
 
 #define DISABLE_METADEX
@@ -477,12 +478,10 @@ public:
 
 extern uint64_t global_MSC_total;
 extern uint64_t global_MSC_RESERVED_total;
-//temp - only supporting 100,000 properties per eco here, research best way to expand array
-//these 4 arrays use about 3MB total memory with 100K properties limit (100000*8*4 bytes)
-extern uint64_t global_balance_money_maineco[100000];
-extern uint64_t global_balance_reserved_maineco[100000];
-extern uint64_t global_balance_money_testeco[100000];
-extern uint64_t global_balance_reserved_testeco[100000];
+extern std::map<uint32_t, uint64_t> global_balance_money_maineco;
+extern std::map<uint32_t, uint64_t> global_balance_reserved_maineco;
+extern std::map<uint32_t, uint64_t> global_balance_money_testeco;
+extern std::map<uint32_t, uint64_t> global_balance_reserved_testeco;
 
 int mastercore_init(void);
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -61,10 +61,10 @@ using namespace leveldb;
 
 //extern uint64_t global_MSC_total;
 //extern uint64_t global_MSC_RESERVED_total;
-extern uint64_t global_balance_money_maineco[100000];
-extern uint64_t global_balance_reserved_maineco[100000];
-extern uint64_t global_balance_money_testeco[100000];
-extern uint64_t global_balance_reserved_testeco[100000];
+extern std::map<uint32_t, uint64_t> global_balance_money_maineco;
+extern std::map<uint32_t, uint64_t> global_balance_reserved_maineco;
+extern std::map<uint32_t, uint64_t> global_balance_money_testeco;
+extern std::map<uint32_t, uint64_t> global_balance_reserved_testeco;
 
 class TxViewDelegate : public QAbstractItemDelegate
 {


### PR DESCRIPTION
1. Doesn't cover full range of potential properties, can result in out-of-bounds violation
2. No need to reserve 100000 elements each
3. [] operator reads an element at position, if key exists, or inserts an element, if not

Build result: https://travis-ci.org/dexX7/mastercore/builds/44842876
