### PR TITLE
Replace: CScript::mscore_getHex() and CScript::mscore_parse()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,6 +46,7 @@ BITCOIN_CORE_H = \
   mastercore_rpc.h \
   mastercore_sp.h \
   mastercore_errors.h \
+  mastercore_script.h \
   mastercore_version.h \
   crypter.h \
   db.h \
@@ -140,6 +141,7 @@ libbitcoin_common_a_SOURCES = \
   mastercore_tx.cpp \
   mastercore_rpc.cpp \
   mastercore_dex.cpp \
+  mastercore_script.cpp \
   mastercore_sp.cpp \
   hash.cpp \
   key.cpp \

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1283,7 +1283,7 @@ uint64_t txFee = 0;
         int nRequired;
 
         // CScript is a std::vector
-        if (msc_debug_script) file_log("scriptPubKey: %s\n", wtx.vout[i].scriptPubKey.mscore_getHex().c_str());
+        if (msc_debug_script) file_log("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
 
         if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired))
         {

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -77,6 +77,7 @@ using namespace mastercore;
 #include "mastercore_tx.h"
 #include "mastercore_sp.h"
 #include "mastercore_errors.h"
+#include "mastercore_script.h"
 #include "mastercore_version.h"
 
 // part of 'breakout' feature
@@ -1146,7 +1147,7 @@ uint64_t txFee = 0;
                   if (msc_debug_parser_data) file_log("saving address_data #%d: %s:%s\n", i, strAddress.c_str(), wtx.vout[i].scriptPubKey.ToString().c_str());
 
                   // saving for Class A processing or reference
-                  wtx.vout[i].scriptPubKey.mscore_parse(script_data);
+                  GetScriptPushes(wtx.vout[i].scriptPubKey, script_data);
                   address_data.push_back(strAddress);
                   value_data.push_back(wtx.vout[i].nValue);
                 }
@@ -1305,7 +1306,9 @@ uint64_t txFee = 0;
             }
           if (msc_debug_script) file_log("\n");
 
-          wtx.vout[i].scriptPubKey.mscore_parse(multisig_script_data, false);
+          // ignore first public key, as it should belong to the sender
+          // and it be used to avoid the creation of unspendable dust
+          GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
         }
               }
             } // end of the outputs' for loop
@@ -3952,38 +3955,6 @@ int validity = 0;
   if ((int)0 == validity) return false;
 
   return true;
-}
-
-std::string CScript::mscore_parse(std::vector<std::string>&msc_parsed, bool bNoBypass) const
-{
-    int count = 0;
-    std::string str;
-    opcodetype opcode;
-    std::vector<unsigned char> vch;
-    const_iterator pc = begin();
-    while (pc < end())
-    {
-        if (!str.empty())
-        {
-            str += "\n";
-        }
-        if (!GetOp(pc, opcode, vch))
-        {
-            str += "[error]";
-            return str;
-        }
-        if (0 <= opcode && opcode <= OP_PUSHDATA4)
-        {
-            str += ValueString(vch);
-            if (count || bNoBypass) msc_parsed.push_back(ValueString(vch));
-            count++;
-        }
-        else
-        {
-            str += GetOpName(opcode);
-        }
-    }
-    return str;
 }
 
 int mastercore_handler_block_begin(int nBlockPrev, CBlockIndex const * pBlockIndex) {

--- a/src/mastercore_script.cpp
+++ b/src/mastercore_script.cpp
@@ -1,0 +1,23 @@
+#include "mastercore_script.h"
+
+#include "script.h"
+#include "util.h"
+
+#include <string>
+#include <vector>
+
+bool GetScriptPushes(const CScript& scriptIn, std::vector<std::string>& vstrRet, bool fSkipFirst)
+{
+    int count = 0;
+    CScript::const_iterator pc = scriptIn.begin();
+    while (pc < scriptIn.end())
+    {
+        opcodetype opcode;
+        std::vector<unsigned char> data;
+        if (!scriptIn.GetOp(pc, opcode, data))
+            return false;
+        if (0 <= opcode && opcode <= OP_PUSHDATA4)
+            if (count++ || !fSkipFirst) vstrRet.push_back(HexStr(data));
+    }
+    return true;
+}

--- a/src/mastercore_script.h
+++ b/src/mastercore_script.h
@@ -1,0 +1,11 @@
+#ifndef MASTERCOIN_SCRIPT_H
+#define MASTERCOIN_SCRIPT_H
+
+#include <string>
+#include <vector>
+
+class CScript;
+
+bool GetScriptPushes(const CScript& scriptIn, std::vector<std::string>& vstrRet, bool fSkipFirst = false);
+
+#endif // MASTERCOIN_SCRIPT_H

--- a/src/script.h
+++ b/src/script.h
@@ -711,7 +711,6 @@ public:
     }
 
     std::string mscore_parse(std::vector<std::string>&msc_parsed, bool bNoBypass = true) const;
-    std::string mscore_getHex() const { return HexStr(begin(), end(), false).c_str(); }
 };
 
 /** Compact serializer for scripts.

--- a/src/script.h
+++ b/src/script.h
@@ -709,8 +709,6 @@ public:
     {
         return CScriptID(Hash160(*this));
     }
-
-    std::string mscore_parse(std::vector<std::string>&msc_parsed, bool bNoBypass = true) const;
 };
 
 /** Compact serializer for scripts.


### PR DESCRIPTION
There was exactly one use of CScript::mscore_getHex(), so it was replaced to reduce the impact on Bitcoin Core. Instead of using a modified version of CScript::ToString(), CScript::mscore_parse() was replaced by an external function, which collects pushed values in a script.

The original state of script.h is now contained.

Build confirmation:
https://travis-ci.org/dexX7/mastercore/builds/45404574

The other friends on TODO: GetScriptForDestination(), GetScriptForMultisig() and maybe GetDustLimit().
