### PR TITLE
Fix reported daemon freezes

### DIFF
--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -107,8 +107,8 @@ void BalanceToJSON(const std::string& address, uint32_t property, Object& balanc
     nReserved += getMPbalance(address, property, SELLOFFER_RESERVE);
 
     if (divisible) {
-        balance_obj.push_back(Pair("balance", FormatDivisibleMP(property, nAvailable)));
-        balance_obj.push_back(Pair("reserved", FormatDivisibleMP(property, nReserved)));
+        balance_obj.push_back(Pair("balance", FormatDivisibleMP(nAvailable)));
+        balance_obj.push_back(Pair("reserved", FormatDivisibleMP(nReserved)));
     } else {
         balance_obj.push_back(Pair("balance", FormatIndivisibleMP(nAvailable)));
         balance_obj.push_back(Pair("reserved", FormatIndivisibleMP(nReserved)));


### PR DESCRIPTION
Alrighty guys, first off the important things; Happy New Year! :)

Now down to business haha - I've debugged and got to the bottom of the reports from several integrators (me included) that 0.0.9 regularly freezes.

First off, it does _not_ freeze in the context of a full hang - let's just get that out the way.  What is happening is that recent modifications to RPC have removed optimizations, causing certain looping RPC calls to take orders of magnitude longer to complete.  For example:

```
Testing a lookup of all SP#3 balances on 0.0.8.2:
#time ./mastercored8 getallbalancesforid_MP 3 >/dev/null

real    0m0.147s
user    0m0.023s
sys     0m0.004s

Testing a lookup of all SP#3 balances on 0.0.9:
#time ./mastercored9 getallbalancesforid_MP 3 >/dev/null

real    6m48.863s
user    0m0.025s
sys     0m0.022s
```

As you can see 0.0.9 is several orders of magnitude (ie thousands of times) slower. MP_\* folders cleared between tests and same command executed multiple times with best result taken to ensure any caches are used etc.  So pretty solid confirmation of what the problem is.

Basically what has happened is that originally certain calls that executed in loops were optimized to do things like lookup the divisibility of a property only once, instead of each iteration of the loop.  The change to BalanceToJSON that was merged in recently changes the model to request divisibility of a property every time we format it - so in the case of the example above (looking up all balances for MaidSafe) we lookup divisibility x thousand times (ie for each address) instead of just once.  

The tl:dr; of it is this increases the processing load dramatically as we go and fetch the property repeatedly and makes certain RPC calls take minutes to complete instead of milliseconds - since the CPU is pegged at 100% during this time the RPC interface is effectively unresponsive and gives the impression of a frozen daemon for some minutes.

So long story short - we don't have a critical freezing bug as reported, but we have close too it; whilst we don't actually hang, we do get busy enough to become unresponsive.

This PR serves to add a required divisibility flag to BalanceToJSON, giving control back to the calling function to specify divisibility.  0.0.9 retested as per above repeated with this PR applied:

```
Testing a lookup of all SP#3 balances on 0.0.9:
#time ./mastercored9 getallbalancesforid_MP 3 >/dev/null

real    0m0.269s
user    0m0.015s
sys     0m0.003s
```

I need to give it a bit more checking/testing but on initial looks like it's sorted.

Thanks 
Z
