### PR TITLE
STO: don't count Exodus as owner

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -4542,6 +4542,9 @@ int rc = PKT_ERROR_STO -1000;
           // do not count the sender
           if (address == sender) continue;
 
+          // do not count Exodus
+          if (address == ExodusAddress()) continue;
+
           int64_t tokens = 0;
 
           tokens += getMPbalance(address, property, BALANCE);


### PR DESCRIPTION
- Exodus is not an active participant in the system
- Regular sends to Exodus are not allowed
- It skews (reg-) testing
- Related spec issue: https://github.com/mastercoin-MSC/spec/issues/299

Note:
This is currently _not_ specified.
