### PR TITLE
Fix STO: require fee only for actual sends

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -4613,7 +4613,7 @@ int rc = PKT_ERROR_STO -1000;
         else
         {
           // dry run code
-          ++n_owners;
+          if (will_really_receive > 0) ++n_owners;
 
           if (msc_debug_sto)
            file_log("%14lu = %s, perc= %20.10lf, piece= %20.10lf, should_get= %14lu, will_really_get= %14lu, sent_so_far= %14lu\n",


### PR DESCRIPTION
A fee should only be paid for sends to owners who actually receive something.

Scenario:

1) A1 starts with 1.00000000 MSC
   A1 starts with 10 MIndiv

   A2 starts with 2 MIndiv
   A3 starts with 3 MIndiv
   A4 starts with 1 MIndiv
   A5 starts with 1 MIndiv
   A6 starts with 1 MIndiv

2) A1 sends 2 MIndiv to owners of MIndiv

3) A1 should have 0.99999998 MSC (-0.00000002 MSC)
   A1 should have 8 MIndiv (-2 MIndiv)

   A2 should have 3 MIndiv (+1 MIndiv)
   A3 should have 4 MIndiv (+1 MIndiv)
   A4 should have 1 MIndiv
   A5 should have 1 MIndiv
   A6 should have 1 MIndiv

Currently A1 would pay 0.00000005 MSC, which is an unjustfied overpayment of
0.00000003 MSC.
