### PR TITLE
Fix and order includes, using directives, makefile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,11 +136,11 @@ libbitcoin_common_a_SOURCES = \
   core.cpp \
   mastercore.cpp \
   mastercore_convert.cpp \
-  mastercore_parse_string.cpp \
-  mastercore_tx.cpp \
-  mastercore_rpc.cpp \
   mastercore_dex.cpp \
+  mastercore_parse_string.cpp \
+  mastercore_rpc.cpp \
   mastercore_sp.cpp \
+  mastercore_tx.cpp \
   hash.cpp \
   key.cpp \
   netbase.cpp \

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -13,71 +13,79 @@
 // global TODO: need locks on the maps in this file & balances (moneys[],reserved[] & raccept[]) !!!
 //
 
+#include "mastercore.h"
+
+#include "mastercore_convert.h"
+#include "mastercore_dex.h"
+#include "mastercore_errors.h"
+#include "mastercore_sp.h"
+#include "mastercore_tx.h"
+#include "mastercore_version.h"
+
 #include "base58.h"
-#include "rpcserver.h"
+#include "chainparams.h"
+#include "coincontrol.h"
 #include "init.h"
+#include "sync.h"
+#include "uint256.h"
 #include "util.h"
 #include "wallet.h"
-// #include "walletdb.h"
-#include "coincontrol.h"
 
-#include <stdint.h>
-#include <string.h>
-#include <set>
-#include <map>
-
-#include <fstream>
-#include <algorithm>
-
-#include <vector>
-
-#include <utility>
-#include <string>
-
-#include <boost/assign/list_of.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
+#include <boost/exception/to_string.hpp>
 #include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
+#include <boost/foreach.hpp>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include <openssl/sha.h>
 
-// #include "tinyformat.h"
+#include "json/json_spirit_value.h"
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include "leveldb/db.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+using boost::algorithm::token_compress_on;
+using boost::multiprecision::cpp_int;
+using boost::multiprecision::int128_t;
+using boost::to_string;
+
+using json_spirit::Array;
+using json_spirit::Pair;
+using json_spirit::Object;
+
+using leveldb::Iterator;
+using leveldb::Slice;
+using leveldb::Status;
+
+using std::ifstream;
+using std::make_pair;
+using std::map;
+using std::ofstream;
+using std::set;
+using std::string;
+using std::vector;
+
+using namespace mastercore;
+
 
 // comment out MY_HACK & others here - used for Unit Testing only !
 // #define MY_HACK
 
-using boost::multiprecision::int128_t;
-using boost::multiprecision::cpp_int;
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace json_spirit;
-using namespace leveldb;
-
 static string exodus_address = "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P";
 static const string exodus_testnet = "mpexoDuSkGGqvqrkrjiFng38QPkJQVFyqv";
 static const string getmoney_testnet = "moneyqMan7uh8FqdCA2BV5yZ8qVrc9ikLP";
-
-#include "mastercore.h"
-
-using namespace mastercore;
-
-#include "mastercore_convert.h"
-#include "mastercore_dex.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
-#include "mastercore_errors.h"
-#include "mastercore_version.h"
 
 // part of 'breakout' feature
 static const int nBlockTop = 0;

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -3,13 +3,34 @@
 //
 // for now (?) class declarations go here -- work in progress; probably will get pulled out into a separate file, note: some declarations are still in the .cpp file
 
-#ifndef _MASTERCOIN
-#define _MASTERCOIN 1
+#ifndef MASTERCORE_H
+#define MASTERCORE_H
 
-#include "netbase.h"
-#include "protocol.h"
+class CBlockIndex;
+class CTransaction;
 
-#include "tinyformat.h"
+#include "sync.h"
+#include "uint256.h"
+#include "util.h"
+
+#include <boost/filesystem/path.hpp>
+
+#include "leveldb/db.h"
+
+#include "json/json_spirit_value.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+using json_spirit::Array;
+
+using std::string;
+using std::vector;
+
 
 #define DISABLE_METADEX
 
@@ -546,5 +567,4 @@ std::string getMasterCoreAlertTextOnly();
 bool parseAlertMessage(std::string rawAlertStr, int32_t *alertType, uint64_t *expiryValue, uint32_t *typeCheck, uint32_t *verCheck, std::string *alertMessage);
 }
 
-#endif
-
+#endif // MASTERCORE_H

--- a/src/mastercore_convert.cpp
+++ b/src/mastercore_convert.cpp
@@ -1,7 +1,7 @@
 #include "mastercore_convert.h"
 
-#include <cmath>
 #include <stdint.h>
+#include <cmath>
 
 namespace mastercore
 {

--- a/src/mastercore_convert.h
+++ b/src/mastercore_convert.h
@@ -1,5 +1,5 @@
-#ifndef _MASTERCORE_CONVERT
-#define _MASTERCORE_CONVERT
+#ifndef MASTERCORE_CONVERT_H
+#define MASTERCORE_CONVERT_H
 
 #include <stdint.h>
 
@@ -37,4 +37,4 @@ void swapByteOrder64(uint64_t&);
     reinterpret_cast<unsigned char *>((ptr)) + (size));
 }
 
-#endif // _MASTERCORE_CONVERT
+#endif // MASTERCORE_CONVERT_H

--- a/src/mastercore_dex.cpp
+++ b/src/mastercore_dex.cpp
@@ -1,62 +1,36 @@
 // DEx & MetaDEx
 
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
+#include "mastercore_dex.h"
+
+#include "mastercore.h"
+#include "mastercore_convert.h"
+#include "mastercore_errors.h"
+#include "mastercore_tx.h"
+
 #include "util.h"
-#include "wallet.h"
 
-#include <stdint.h>
-#include <string.h>
-
-#include <map>
-#include <set>
-
-#include <fstream>
-#include <algorithm>
-
-#include <vector>
-
-#include <utility>
-#include <string>
-
-#include <boost/assign/list_of.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
 
 #include <openssl/sha.h>
 
-#include <boost/math/constants/constants.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
-#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <stdint.h>
 
-using boost::multiprecision::int128_t;
-using boost::multiprecision::cpp_int;
-using boost::multiprecision::cpp_dec_float;
-using boost::multiprecision::cpp_dec_float_100;
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace json_spirit;
-using namespace leveldb;
+using boost::algorithm::token_compress_on;
 
-#include "mastercore.h"
+using std::endl;
+using std::ofstream;
+using std::string;
 
 using namespace mastercore;
 
-#include "mastercore_convert.h"
-#include "mastercore_dex.h"
-#include "mastercore_tx.h"
 
 extern int msc_debug_metadex1, msc_debug_metadex2, msc_debug_metadex3;
 

--- a/src/mastercore_dex.h
+++ b/src/mastercore_dex.h
@@ -1,7 +1,32 @@
-#ifndef _MASTERCOIN_DEX
-#define _MASTERCOIN_DEX 1
+#ifndef MASTERCORE_DEX_H
+#define MASTERCORE_DEX_H
 
 #include "mastercore.h"
+
+#include "main.h"
+#include "uint256.h"
+
+#include <boost/format.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
+#include <openssl/sha.h>
+
+#include <stdint.h>
+
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+
+using boost::multiprecision::cpp_dec_float_100;
+
+using std::endl;
+using std::ofstream;
+using std::string;
+
+typedef cpp_dec_float_100 XDOUBLE;
+
 
 // this is the internal format for the offer primary key (TODO: replace by a class method)
 #define STR_SELLOFFER_ADDR_PROP_COMBO(x) ( x + "-" + strprintf("%d", prop))
@@ -12,8 +37,6 @@
 #define DISPLAY_PRECISION_LEN  50
 #define INTERNAL_PRECISION_LEN 50
 
-#include <boost/multiprecision/cpp_dec_float.hpp>
-using boost::multiprecision::cpp_dec_float_100;
 
 // a single outstanding offer -- from one seller of one property, internally may have many accepts
 class CMPOffer
@@ -169,9 +192,6 @@ public:
 
 };  // end of CMPAccept class
 
-typedef cpp_dec_float_100 XDOUBLE;
-// typedef double XDOUBLE;
-
 // a metadex trade
 class CMPMetaDEx
 {
@@ -301,5 +321,4 @@ md_Set *get_Indexes(md_PricesMap *p, XDOUBLE price);
 void MetaDEx_debug_print(bool bShowPriceLevel = false, bool bDisplay = false);
 }
 
-#endif // #ifndef _MASTERCOIN_DEX
-
+#endif // MASTERCORE_DEX_H

--- a/src/mastercore_errors.h
+++ b/src/mastercore_errors.h
@@ -1,5 +1,7 @@
-#ifndef _MASTERCOIN_ERRORS
-#define _MASTERCOIN_ERRORS 1
+#ifndef MASTERCORE_ERRORS_H
+#define MASTERCORE_ERRORS_H
+
+#include <string>
 
 enum MPRPCErrorCode
 {
@@ -80,4 +82,4 @@ inline std::string error_str(int ec) {
   return ec_str;
 }
 
-#endif // _MASTERCOIN_ERRORS
+#endif // MASTERCORE_ERRORS_H

--- a/src/mastercore_parse_string.cpp
+++ b/src/mastercore_parse_string.cpp
@@ -1,10 +1,11 @@
 #include "mastercore_parse_string.h"
 
+#include <boost/lexical_cast.hpp>
+
 #include <stdint.h>
+
 #include <algorithm>
 #include <string>
-
-#include <boost/lexical_cast.hpp>
 
 namespace mastercore
 {

--- a/src/mastercore_parse_string.h
+++ b/src/mastercore_parse_string.h
@@ -1,5 +1,5 @@
-#ifndef _MASTERCOIN_PARSE_STRING
-#define _MASTERCOIN_PARSE_STRING
+#ifndef MASTERCORE_PARSE_STRING_H
+#define MASTERCORE_PARSE_STRING_H
 
 #include <stdint.h>
 #include <string>
@@ -17,4 +17,4 @@ namespace mastercore
 int64_t StrToInt64(const std::string& str, bool divisible);
 }
 
-#endif // _MASTERCOIN_PARSE_STRRING
+#endif // MASTERCORE_PARSE_STRING_H

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -1,48 +1,51 @@
 // RPC calls
 
-#include "rpcserver.h"
-#include "util.h"
-#include "init.h"
-#include "wallet.h"
-#include "clientversion.h"
-
-#include <stdint.h>
-#include <string.h>
-#include <map>
-
-#include <fstream>
-#include <vector>
-#include <string>
-
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-
-#include <openssl/sha.h>
-
-using namespace std;
-using namespace boost;
-using namespace json_spirit;
+#include "mastercore_rpc.h"
 
 #include "mastercore.h"
+#include "mastercore_convert.h"
+#include "mastercore_dex.h"
+#include "mastercore_errors.h"
+#include "mastercore_parse_string.h"
+#include "mastercore_sp.h"
+#include "mastercore_tx.h"
+#include "mastercore_version.h"
+
+#include "core.h"
+#include "init.h"
+#include "main.h"
+#include "rpcserver.h"
+#include "uint256.h"
+#include "util.h"
+#include "wallet.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/exception/to_string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include "json/json_spirit_value.h"
+
+#include <stdint.h>
+
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using boost::algorithm::token_compress_on;
+using boost::to_string;
+
+using json_spirit::Array;
+using json_spirit::Object;
+using json_spirit::Pair;
+using json_spirit::Value;
+
+using std::map;
+using std::runtime_error;
+using std::string;
 
 using namespace mastercore;
 
-#include "mastercore_convert.h"
-#include "mastercore_dex.h"
-#include "mastercore_parse_string.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
-#include "mastercore_rpc.h"
-#include "mastercore_errors.h"
-#include "mastercore_version.h"
 
 void PropertyToJSON(const CMPSPInfo::Entry& sProperty, Object& property_obj)
 {
@@ -1359,7 +1362,7 @@ Value listblocktransactions_MP(const Array& params, bool fHelp)
 }
 
 // this function standardizes the RPC output for gettransaction_MP and listtransaction_MP into a central function
-int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddress = "")
+int populateRPCTransactionObject(const uint256& txid, Object *txobj, const string& filterAddress = "")
 {
     //uint256 hash;
     //hash.SetHex(params[0].get_str());

--- a/src/mastercore_rpc.h
+++ b/src/mastercore_rpc.h
@@ -1,8 +1,12 @@
-#ifndef _MASTERCORE_RPC
-#define _MASTERCORE_RPC
+#ifndef MASTERCORE_RPC_H
+#define MASTERCORE_RPC_H
 
-  #include "mastercore.h"
-  int populateRPCTransactionObject(uint256 txid, Object *txobj, string filterAddress);
+#include "json/json_spirit_value.h"
 
-#endif // #ifndef _MASTERCORE_RPC
+#include <string>
 
+class uint256;
+
+int populateRPCTransactionObject(const uint256& txid, json_spirit::Object *txobj, const std::string& filterAddress);
+
+#endif // MASTERCORE_RPC_H

--- a/src/mastercore_sp.cpp
+++ b/src/mastercore_sp.cpp
@@ -1,46 +1,39 @@
 // Smart Properties & Crowd Sales
 
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
-#include "util.h"
-#include "wallet.h"
+#include "mastercore_sp.h"
 
-#include <stdint.h>
-#include <string.h>
+#include "mastercore.h"
 
-#include <fstream>
-#include <algorithm>
+#include "main.h"
+#include "uint256.h"
 
-#include <vector>
-
-#include <utility>
-#include <string>
-
-#include <boost/assign/list_of.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
 #include <boost/filesystem.hpp>
-
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace json_spirit;
-using namespace leveldb;
+#include "json/json_spirit_value.h"
+#include "json/json_spirit_writer_template.h"
 
-#include "mastercore.h"
+#include <stdint.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+using boost::algorithm::token_compress_on;
+
+using json_spirit::Object;
+using json_spirit::Value;
+using json_spirit::write_string;
+
+using std::string;
 
 using namespace mastercore;
 
-#include "mastercore_sp.h"
 
 unsigned int CMPSPInfo::updateSP(unsigned int propertyID, Entry const &info)
 {

--- a/src/mastercore_sp.h
+++ b/src/mastercore_sp.h
@@ -1,7 +1,46 @@
-#ifndef _MASTERCOIN_SP
-#define _MASTERCOIN_SP 1
+#ifndef MASTERCORE_SP_H
+#define MASTERCORE_SP_H
 
 #include "mastercore.h"
+
+class CBlockIndex;
+
+#include "uint256.h"
+#include "util.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <openssl/sha.h>
+
+#include "json/json_spirit_reader_template.h"
+#include "json/json_spirit_value.h"
+
+#include "leveldb/db.h"
+#include "leveldb/write_batch.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+using boost::algorithm::token_compress_on;
+
+using json_spirit::Object;
+using json_spirit::Pair;
+using json_spirit::Value;
+using json_spirit::read_string;
+using json_spirit::obj_type;
+
+using std::endl;
+using std::ofstream;
+using std::string;
+
 
 class CMPSPInfo
 {
@@ -505,5 +544,4 @@ unsigned int eraseExpiredCrowdsale(CBlockIndex const * pBlockIndex);
 void dumpCrowdsaleInfo(const string &address, CMPCrowd &crowd, bool bExpired = false);
 }
 
-#endif // _MASTERCOIN_SP
-
+#endif // MASTERCORE_SP_H

--- a/src/mastercore_tx.cpp
+++ b/src/mastercore_tx.cpp
@@ -1,57 +1,28 @@
 // Master Protocol transaction code
 
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
-#include "util.h"
-#include "wallet.h"
-#include "alert.h"
-
-#include <stdint.h>
-#include <string.h>
-#include <map>
-
-#include <fstream>
-#include <algorithm>
-
-#include <vector>
-
-#include <utility>
-#include <string>
-
-#include <boost/assign/list_of.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-
-#include <openssl/sha.h>
-
-#include <boost/multiprecision/cpp_int.hpp>
-
-using boost::multiprecision::int128_t;
-using boost::multiprecision::cpp_int;
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace json_spirit;
-using namespace leveldb;
+#include "mastercore_tx.h"
 
 #include "mastercore.h"
+#include "mastercore_convert.h"
+#include "mastercore_dex.h"
+#include "mastercore_sp.h"
+
+#include "alert.h"
+#include "util.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <algorithm>
+#include <vector>
+
+using boost::algorithm::token_compress_on;
 
 using namespace mastercore;
 
-#include "mastercore_convert.h"
-#include "mastercore_dex.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
 
 // initial packet interpret step
 int CMPTransaction::step1()

--- a/src/mastercore_tx.h
+++ b/src/mastercore_tx.h
@@ -1,7 +1,25 @@
-#ifndef _MASTERCOIN_TX
-#define _MASTERCOIN_TX 1
+#ifndef MASTERCORE_TX_H
+#define MASTERCORE_TX_H
+
+class CMPOffer;
+class CMPMetaDEx;
 
 #include "mastercore.h"
+
+#include "uint256.h"
+#include "util.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <string>
+#include <utility>
+
+using std::pair;
+using std::string;
+
+using mastercore::c_strMasterProtocolTXType;
 
 // The class responsible for tx interpreting/parsing.
 //
@@ -194,5 +212,4 @@ public:
 
 int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigned int idx, CMPTransaction *mp_tx, unsigned int nTime=0);
 
-#endif // #ifndef _MASTERCOIN_TX
-
+#endif // MASTERCORE_TX_H

--- a/src/mastercore_version.h
+++ b/src/mastercore_version.h
@@ -1,9 +1,5 @@
-// Copyright (c) 2013 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef _MASTERCORE_VERSION_H
-#define _MASTERCORE_VERSION_H
+#ifndef MASTERCORE_VERSION_H
+#define MASTERCORE_VERSION_H
 
   #define OMNICORE_VERSION_BASE 90 // 82 = 0.0.8.2   91 = 0.0.9.1   103 = 0.0.10.3 etc
   #define OMNICORE_VERSION_TYPE "-dev" // switch to -rel for tags, switch back to -dev for development
@@ -18,4 +14,4 @@
   #define OMNICORE_VERSION_TYPE "-dev"
   */
 
-#endif
+#endif // MASTERCORE_VERSION_H

--- a/src/qt/balancesview.cpp
+++ b/src/qt/balancesview.cpp
@@ -4,63 +4,11 @@
 
 #include "balancesview.h"
 
-#include "addresstablemodel.h"
-#include "bitcoinunits.h"
-#include "csvmodelwriter.h"
-#include "editaddressdialog.h"
-#include "guiutil.h"
-#include "optionsmodel.h"
-#include "transactiondescdialog.h"
+#include "mastercore.h"
+
 #include "transactionfilterproxy.h"
-#include "transactionrecord.h"
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
-#include "wallet.h"
-
-#include "ui_interface.h"
-
-#include <boost/filesystem.hpp>
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-
-// potentially overzealous includes here
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
-#include "util.h"
-#include <fstream>
-#include <algorithm>
-#include <vector>
-#include <utility>
-#include <string>
-#include <boost/assign/list_of.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-// end potentially overzealous includes
-using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
-
-#include "mastercore.h"
-using namespace mastercore;
-
-// potentially overzealous using here
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace leveldb;
-// end potentially overzealous using
-
-#include "mastercore_dex.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
 
 #include <QComboBox>
 #include <QDateTimeEdit>
@@ -77,6 +25,15 @@ using namespace leveldb;
 #include <QTableView>
 #include <QUrl>
 #include <QVBoxLayout>
+
+#include <string>
+#include <sstream>
+
+using std::string;
+using std::ostringstream;
+
+using namespace mastercore;
+
 
 BalancesView::BalancesView(QWidget *parent) :
     QWidget(parent), model(0), balancesView(0)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -5,6 +5,9 @@
 #include "overviewpage.h"
 #include "ui_overviewpage.h"
 
+#include "mastercore.h"
+#include "mastercore_sp.h"
+
 #include "bitcoinunits.h"
 #include "clientmodel.h"
 #include "guiconstants.h"
@@ -13,48 +16,20 @@
 #include "transactionfilterproxy.h"
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
-#include "wallet.h"
 
-// potentially overzealous includes here
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
-#include "util.h"
-#include <fstream>
-#include <algorithm>
-#include <vector>
-#include <utility>
-#include <string>
-#include <boost/assign/list_of.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-// end potentially overzealous includes
-using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
-
-#include "mastercore.h"
-using namespace mastercore;
-
-// potentially overzealous using here
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace leveldb;
-// end potentially overzealous using
-
-#include "mastercore_dex.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
+#include "main.h"
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
+
+#include <stdint.h>
+
+#include <string>
+
+using std::string;
+
+using namespace mastercore;
+
 
 #define DECORATION_SIZE 64
 #define NUM_ITEMS 5

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -5,65 +5,30 @@
 #include "sendmpdialog.h"
 #include "ui_sendmpdialog.h"
 
-#include "addresstablemodel.h"
-#include "bitcoinunits.h"
-#include "coincontroldialog.h"
+#include "mastercore.h"
+#include "mastercore_parse_string.h"
+
 #include "guiutil.h"
 #include "optionsmodel.h"
 #include "walletmodel.h"
-#include "wallet.h"
+
 #include "base58.h"
-#include "coincontrol.h"
-#include "ui_interface.h"
+#include "sync.h"
+#include "uint256.h"
 
-#include <boost/filesystem.hpp>
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-
-// potentially overzealous includes here
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
-#include "util.h"
-#include <fstream>
-#include <algorithm>
-#include <vector>
-#include <utility>
-#include <string>
-#include <boost/assign/list_of.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-// end potentially overzealous includes
-using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
-
-#include "mastercore.h"
-using namespace mastercore;
-
-// potentially overzealous using here
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace leveldb;
-// end potentially overzealous using
-
-#include "mastercore_dex.h"
-#include "mastercore_parse_string.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
 
 #include <QDateTime>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QTextDocument>
+
+#include <string>
+
+using std::string;
+
+using namespace mastercore;
+
 
 SendMPDialog::SendMPDialog(QWidget *parent) :
     QDialog(parent),

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -4,6 +4,9 @@
 
 #include "transactiontablemodel.h"
 
+#include "mastercore.h"
+#include "mastercore_sp.h"
+
 #include "addresstablemodel.h"
 #include "bitcoinunits.h"
 #include "guiconstants.h"
@@ -13,54 +16,13 @@
 #include "transactionrecord.h"
 #include "walletmodel.h"
 
-#include "main.h"
 #include "sync.h"
 #include "uint256.h"
+#include "ui_interface.h"
 #include "util.h"
 #include "wallet.h"
 
-#include <boost/filesystem.hpp>
-
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-
-// potentially overzealous includes here
-#include "base58.h"
-#include "rpcserver.h"
-#include "init.h"
-#include "util.h"
-#include <fstream>
-#include <algorithm>
-#include <vector>
-#include <utility>
-#include <string>
-#include <boost/assign/list_of.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/find.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include "json/json_spirit_utils.h"
-#include "json/json_spirit_value.h"
-#include "leveldb/db.h"
-#include "leveldb/write_batch.h"
-// end potentially overzealous includes
-using namespace json_spirit; // since now using Array in mastercore.h this needs to come first
-
-#include "mastercore.h"
-using namespace mastercore;
-
-// potentially overzealous using here
-using namespace std;
-using namespace boost;
-using namespace boost::assign;
-using namespace leveldb;
-// end potentially overzealous using
-
-#include "mastercore_dex.h"
-#include "mastercore_tx.h"
-#include "mastercore_sp.h"
+#include <boost/foreach.hpp>
 
 #include <QColor>
 #include <QDateTime>
@@ -68,7 +30,10 @@ using namespace leveldb;
 #include <QIcon>
 #include <QList>
 
-extern CWallet* pwalletMain;
+#include <map>
+
+using namespace mastercore;
+
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {


### PR DESCRIPTION
There were many missing, but also many needless includes, as well as too wide imports of namespaces, which can lead to ambiguity.

Missing dependencies make it difficult to use Master Core in a different context, for example, and especially, in unit tests - which was by the way the reason I started with those maybe silly one-method-files like convert and parse_string, ...

Passes all tests:
- Boost
- [BitcoindComparisionTool](https://github.com/TheBlueMatt/test-scripts/tree/38b490a2599d422b12d5ce8f165792f63fd8f54f)
- [mastercore-rpc-tests](https://github.com/dexX7/mastercore-rpc-tests/tree/ebefe5d7a9a0788c96f3faa2debfc9880c2b5346)
- [bitcoin-spock](https://github.com/msgilligan/bitcoin-spock/tree/9a19a3bda7626d7719b58713181b2f49710175cc) ([test report](https://circle-artifacts.com/gh/dexX7/mastercore/32/artifacts/0/tmp/circle-artifacts.gvG7P9g/reports/tests/index.html))

Build log and results:
- [Circle CI](https://circleci.com/gh/dexX7/mastercore/32)
- [Travis CI](https://travis-ci.org/dexX7/mastercore/builds/48979402)

Basically nothing else than the dependency sections were touched.
